### PR TITLE
deploy docs using gh-pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -2,9 +2,17 @@ name: DoxyGen build
 
 on:
   pull_request:
+    branches:
+      - master
   push:
+    branches:
+      - master
   release:
-    types: [published, edited]
+    branches:
+      - master
+    types:
+      - published
+      - edited
 
 jobs:
   build-doxygen:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,37 @@
+name: DoxyGen build
+
+on:
+  pull_request:
+  push:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-doxygen:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: get latest release version number
+      id: latest_ver
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: nRF24/RF24Gateway
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: overwrite doxygen tags
+      run: |
+        mkdir docs
+        touch doxygenAction
+        echo "PROJECT_NUMBER = ${{ steps.latest_ver.outputs.release }}" >> doxygenAction
+        echo "@INCLUDE = doxygenAction" >> Doxyfile
+    - name: build doxygen
+      uses: mattnotmitt/doxygen-action@v1
+      with:
+          working-directory: '.'
+          doxyfile-path: './Doxyfile'
+    - name: upload to github pages
+      if: ${{ github.event_name == 'release'}}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore docs folder
+docs/

--- a/Doxyfile
+++ b/Doxyfile
@@ -51,14 +51,14 @@ PROJECT_BRIEF          = "TMRh20 - Pushing the practical limits of RF24 modules"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = 
+PROJECT_LOGO           =
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "C:/Users/tmrh20/Documents/ArduinoBuilds/RF24Gateway Docs"
+OUTPUT_DIRECTORY       = ./docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -162,7 +162,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = 
+STRIP_FROM_PATH        =
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -171,7 +171,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = 
+STRIP_FROM_INC_PATH    =
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -238,13 +238,13 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                = 
+ALIASES                =
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              = 
+TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -640,7 +640,7 @@ GENERATE_DEPRECATEDLIST= YES
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
 
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines that the
 # initial value of a variable or macro / define can have for it to appear in the
@@ -682,7 +682,7 @@ SHOW_NAMESPACES        = NO
 # by doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.
 
-FILE_VERSION_FILTER    = 
+FILE_VERSION_FILTER    =
 
 # The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
 # by doxygen. The layout file controls the global structure of the generated
@@ -695,7 +695,7 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            = 
+LAYOUT_FILE            =
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
@@ -705,7 +705,7 @@ LAYOUT_FILE            =
 # LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
 # search path. See also \cite for info how to create references.
 
-CITE_BIB_FILES         = 
+CITE_BIB_FILES         =
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -764,7 +764,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = 
+WARN_LOGFILE           =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -857,7 +857,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -873,7 +873,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = 
+EXCLUDE_PATTERNS       =
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -884,7 +884,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        =
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -897,7 +897,7 @@ EXAMPLE_PATH           = examples
 # *.h) to filter out the source-files in the directories. If left blank all
 # files are included.
 
-EXAMPLE_PATTERNS       = 
+EXAMPLE_PATTERNS       =
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands
@@ -927,7 +927,7 @@ IMAGE_PATH             = examples/ncurses
 # code is scanned, but not when the output code is generated. If lines are added
 # or removed, the anchors will not be placed correctly.
 
-INPUT_FILTER           = 
+INPUT_FILTER           =
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the
@@ -936,7 +936,7 @@ INPUT_FILTER           =
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        = 
+FILTER_PATTERNS        =
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for
@@ -951,14 +951,14 @@ FILTER_SOURCE_FILES    = NO
 # *.ext= (so without naming a filter).
 # This tag requires that the tag FILTER_SOURCE_FILES is set to YES.
 
-FILTER_SOURCE_PATTERNS = 
+FILTER_SOURCE_PATTERNS =
 
 # If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
 # is part of the input, its contents will be placed on the main page
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = 
+USE_MDFILE_AS_MAINPAGE =
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1063,7 +1063,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          = 
+CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -1089,7 +1089,7 @@ COLS_IN_ALPHA_INDEX    = 10
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -1133,7 +1133,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            = 
+HTML_HEADER            =
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1143,7 +1143,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            = 
+HTML_FOOTER            =
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1155,7 +1155,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        = 
+HTML_STYLESHEET        =
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1178,7 +1178,7 @@ HTML_EXTRA_STYLESHEET  = doxygen-custom.css
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = 
+HTML_EXTRA_FILES       =
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
@@ -1307,7 +1307,7 @@ GENERATE_HTMLHELP      = NO
 # written to the html output directory.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_FILE               = 
+CHM_FILE               =
 
 # The HHC_LOCATION tag can be used to specify the location (absolute path
 # including file name) of the HTML help compiler (hhc.exe). If non-empty,
@@ -1315,7 +1315,7 @@ CHM_FILE               =
 # The file has to be specified with full path.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-HHC_LOCATION           = 
+HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
 # (YES) or that it should be included in the master .chm file (NO).
@@ -1328,7 +1328,7 @@ GENERATE_CHI           = NO
 # and project file content.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_INDEX_ENCODING     = 
+CHM_INDEX_ENCODING     =
 
 # The BINARY_TOC flag controls whether a binary table of contents is generated
 # (YES) or a normal table of contents (NO) in the .chm file. Furthermore it
@@ -1359,7 +1359,7 @@ GENERATE_QHP           = NO
 # the HTML output folder.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QCH_FILE               = 
+QCH_FILE               =
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
@@ -1384,7 +1384,7 @@ QHP_VIRTUAL_FOLDER     = doc
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_NAME   = 
+QHP_CUST_FILTER_NAME   =
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
@@ -1392,21 +1392,21 @@ QHP_CUST_FILTER_NAME   =
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_ATTRS  = 
+QHP_CUST_FILTER_ATTRS  =
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
 # http://qt-project.org/doc/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_SECT_FILTER_ATTRS  = 
+QHP_SECT_FILTER_ATTRS  =
 
 # The QHG_LOCATION tag can be used to specify the location of Qt's
 # qhelpgenerator. If non-empty doxygen will try to run qhelpgenerator on the
 # generated .qhp file.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHG_LOCATION           = 
+QHG_LOCATION           =
 
 # If the GENERATE_ECLIPSEHELP tag is set to YES, additional index files will be
 # generated, together with the HTML files, they form an Eclipse help plugin. To
@@ -1539,7 +1539,7 @@ MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_EXTENSIONS     = 
+MATHJAX_EXTENSIONS     =
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site
@@ -1547,7 +1547,7 @@ MATHJAX_EXTENSIONS     =
 # example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_CODEFILE       = 
+MATHJAX_CODEFILE       =
 
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box for
 # the HTML output. The underlying search engine uses javascript and DHTML and
@@ -1607,7 +1607,7 @@ EXTERNAL_SEARCH        = NO
 # Searching" for details.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-SEARCHENGINE_URL       = 
+SEARCHENGINE_URL       =
 
 # When SERVER_BASED_SEARCH and EXTERNAL_SEARCH are both enabled the unindexed
 # search data is written to a file for indexing by an external tool. With the
@@ -1623,7 +1623,7 @@ SEARCHDATA_FILE        = searchdata.xml
 # projects and redirect the results back to the right project.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTERNAL_SEARCH_ID     = 
+EXTERNAL_SEARCH_ID     =
 
 # The EXTRA_SEARCH_MAPPINGS tag can be used to enable searching through doxygen
 # projects other than the one defined by this configuration file, but that are
@@ -1633,7 +1633,7 @@ EXTERNAL_SEARCH_ID     =
 # EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTRA_SEARCH_MAPPINGS  = 
+EXTRA_SEARCH_MAPPINGS  =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output
@@ -1697,7 +1697,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         = 
+EXTRA_PACKAGES         =
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -1713,7 +1713,7 @@ EXTRA_PACKAGES         =
 # to HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_HEADER           = 
+LATEX_HEADER           =
 
 # The LATEX_FOOTER tag can be used to specify a personal LaTeX footer for the
 # generated LaTeX document. The footer should contain everything after the last
@@ -1724,7 +1724,7 @@ LATEX_HEADER           =
 # Note: Only use a user-defined footer if you know what you are doing!
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_FOOTER           = 
+LATEX_FOOTER           =
 
 # The LATEX_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # LaTeX style sheets that are included after the standard style sheets created
@@ -1735,7 +1735,7 @@ LATEX_FOOTER           =
 # list).
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_STYLESHEET = 
+LATEX_EXTRA_STYLESHEET =
 
 # The LATEX_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the LATEX_OUTPUT output
@@ -1743,7 +1743,7 @@ LATEX_EXTRA_STYLESHEET =
 # markers available.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_FILES      = 
+LATEX_EXTRA_FILES      =
 
 # If the PDF_HYPERLINKS tag is set to YES, the LaTeX that is generated is
 # prepared for conversion to PDF (using ps2pdf or pdflatex). The PDF file will
@@ -1843,14 +1843,14 @@ RTF_HYPERLINKS         = NO
 # default style sheet that doxygen normally uses.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_STYLESHEET_FILE    = 
+RTF_STYLESHEET_FILE    =
 
 # Set optional variables used in the generation of an RTF document. Syntax is
 # similar to doxygen's config file. A template extensions file can be generated
 # using doxygen -e rtf extensionFile.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_EXTENSIONS_FILE    = 
+RTF_EXTENSIONS_FILE    =
 
 # If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
 # with syntax highlighting in the RTF output.
@@ -1895,7 +1895,7 @@ MAN_EXTENSION          = .3
 # MAN_EXTENSION with the initial . removed.
 # This tag requires that the tag GENERATE_MAN is set to YES.
 
-MAN_SUBDIR             = 
+MAN_SUBDIR             =
 
 # If the MAN_LINKS tag is set to YES and doxygen generates man output, then it
 # will generate one additional man file for each entity documented in the real
@@ -2008,7 +2008,7 @@ PERLMOD_PRETTY         = YES
 # overwrite each other's variables.
 # This tag requires that the tag GENERATE_PERLMOD is set to YES.
 
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
@@ -2049,7 +2049,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = 
+INCLUDE_PATH           =
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2057,7 +2057,7 @@ INCLUDE_PATH           =
 # used.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-INCLUDE_FILE_PATTERNS  = 
+INCLUDE_FILE_PATTERNS  =
 
 # The PREDEFINED tag can be used to specify one or more macro names that are
 # defined before the preprocessor is started (similar to the -D option of e.g.
@@ -2067,7 +2067,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = 
+PREDEFINED             =
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2076,7 +2076,7 @@ PREDEFINED             =
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = 
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2105,13 +2105,13 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = 
+TAGFILES               =
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = 
+GENERATE_TAGFILE       =
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be
@@ -2160,14 +2160,14 @@ CLASS_DIAGRAMS         = YES
 # the mscgen tool resides. If left empty the tool is assumed to be found in the
 # default search path.
 
-MSCGEN_PATH            = 
+MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
 # If left empty dia is assumed to be found in the default search path.
 
-DIA_PATH               = 
+DIA_PATH               =
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
@@ -2216,7 +2216,7 @@ DOT_FONTSIZE           = 10
 # the path where dot can find it using this tag.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTPATH           = 
+DOT_FONTPATH           =
 
 # If the CLASS_GRAPH tag is set to YES then doxygen will generate a graph for
 # each documented class showing the direct and indirect inheritance relations.
@@ -2360,26 +2360,26 @@ INTERACTIVE_SVG        = NO
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = 
+DOT_PATH               =
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile
 # command).
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOTFILE_DIRS           = 
+DOTFILE_DIRS           =
 
 # The MSCFILE_DIRS tag can be used to specify one or more directories that
 # contain msc files that are included in the documentation (see the \mscfile
 # command).
 
-MSCFILE_DIRS           = 
+MSCFILE_DIRS           =
 
 # The DIAFILE_DIRS tag can be used to specify one or more directories that
 # contain dia files that are included in the documentation (see the \diafile
 # command).
 
-DIAFILE_DIRS           = 
+DIAFILE_DIRS           =
 
 # When using plantuml, the PLANTUML_JAR_PATH tag should be used to specify the
 # path where java can find the plantuml.jar file. If left blank, it is assumed
@@ -2387,12 +2387,12 @@ DIAFILE_DIRS           =
 # generate a warning when it encounters a \startuml command in this case and
 # will not generate output for the diagram.
 
-PLANTUML_JAR_PATH      = 
+PLANTUML_JAR_PATH      =
 
 # When using plantuml, the specified paths are searched for files specified by
 # the !include statement in a plantuml block.
 
-PLANTUML_INCLUDE_PATH  = 
+PLANTUML_INCLUDE_PATH  =
 
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes
@@ -2453,3 +2453,4 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+

--- a/Doxyfile
+++ b/Doxyfile
@@ -240,12 +240,6 @@ TAB_SIZE               = 4
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all
@@ -1642,7 +1636,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2134,12 +2128,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2152,15 +2140,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/RF24Gateway.h
+++ b/RF24Gateway.h
@@ -317,14 +317,14 @@ private:
  *
  * @section Installation Installation
  *
- * See http://tmrh20.github.io/RF24 for installation instructions using the installer, or clone the RF24 libs and run 'make install' for each one.
+ * See http://nRF24.github.io/RF24 for installation instructions using the installer, or clone the RF24 libs and run 'make install' for each one.
  *
  * After running the installer, RF24Gateway will be installed at rf24libs/RF24Gateway. <b><a href="examples.html">Examples</a></b> are included for operating the gateway
  * as well as client scripts & programs to control nodes via http requests.
  *
  * Note: RF24Gateway is tested with and defaults to using RF24Mesh. Sensor nodes must also use RF24Mesh or be statically assigned within RF24Mesh.
  *
- * See http://tmrh20.github.io/RF24Ethernet/ for related documentation for use with RF24Gateway.
+ * See http://nRF24.github.io/RF24Ethernet/ for related documentation for use with RF24Gateway.
  *
  * @section HowItWorks How It Works
  *
@@ -356,7 +356,7 @@ private:
  * sudo sysctl -w net.ipv4.ip_forward=1
  * sudo iptables -t nat -A POSTROUTING -j MASQUERADE @endcode
  *
- * See http://tmrh20.github.io/RF24Ethernet/ConfigAndSetup.html for more info
+ * See http://nRF24.github.io/RF24Ethernet/ConfigAndSetup.html for more info
  *
  * @section AdvConfig Advanced Configuration
  *

--- a/RF24Gateway.h
+++ b/RF24Gateway.h
@@ -7,7 +7,7 @@
 /**
  * @file RF24Gateway.h
  *
- * Class declaration for RF24Gateway 
+ * Class declaration for RF24Gateway
  */
   #include "net/if_arp.h"
   #include <cstdlib>
@@ -25,26 +25,25 @@
   #include <sys/ioctl.h>
   #include <netdb.h>
   #include <fstream>
-  
+
   #include <RF24/RF24.h>
   #include <RF24Network/RF24Network.h>
   #include <RF24Mesh/RF24Mesh.h>
-  
+
 #ifndef IFF_MULTI_QUEUE
 	#define IFF_MULTI_QUEUE 0x0100
-#endif  
+#endif
 
 #define DEBUG 0
 
 #define BACKLOG     10  /* Passed to listen() */
-  
+
   class RF24;
   class RF24Network;
   class RF24Mesh;
-  
+
 class RF24Gateway {
 
-  /**@}*/
   /**
    * @name RF24Gateway (RPi/Linux)
    *
@@ -58,7 +57,7 @@ public:
    * RF24Gateway constructor.
    */
   RF24Gateway(RF24& _radio,RF24Network& _network, RF24Mesh& _mesh);
-  
+
   /**
    * Begin function for use with RF24Mesh (TUN interface)
    *
@@ -70,11 +69,11 @@ public:
    * @code uint8_t nodeID; gw.begin(nodeID); //Start the gateway using RF24Mesh, with nodeID 1 (Child node) @endcode
    */
   void begin(uint8_t nodeID=0, uint8_t channel=97,rf24_datarate_e data_rate=RF24_1MBPS);
-  
+
   /**
    * Begin function for use with a TAP (Ethernet) interface. RF24Mesh can be used for address assignment, but
    * ARP will be used to perform the lookups.
-   * 
+   *
    * @param address The RF24Network address to use
    * @param channel The radio channel (0-127) to use
    * @param data_rate The RF24 datarate to use (RF24_250KBPS, RF24_1MBPS, RF24_2MBPS)
@@ -85,17 +84,17 @@ public:
    * @code uint16_t address=01; gw.begin(address); //Start the gateway without using RF24Mesh, with RF24Network address 01 (Child) @endcode
    */
   void begin(uint16_t address, uint8_t channel=97, rf24_datarate_e data_rate=RF24_1MBPS, bool meshEnable=0, uint8_t nodeID=0 );
-  
+
   /**
    * Once the Gateway has been started via begin() , call setIP to configure the IP and
    * subnet mask.
    *
-   * @param ip A character array containing the numeric IP address ie: 192.168.1.1
+   * @param ip_addr A character array containing the numeric IP address ie: 192.168.1.1
    * @param mask A character array containing the subnet mask ie: 255.255.255.0
    * @return -1 if failed, 0 on success
    */
-  int setIP( char *ip_addr, char *mask);
-  
+  int setIP(char *ip_addr, char *mask);
+
   /**
    * Calling update() keeps the network and mesh layers active and processing data. This needs to be called regularly.
    * @code
@@ -104,56 +103,56 @@ public:
    *  ...do something
    * }
    * @endcode
-   * @param interrupts. Set true if called from an interrupt handler & call poll() from the main loop or a thread.
+   * @param interrupts Set true if called from an interrupt handler & call poll() from the main loop or a thread.
    */
-  void update(bool interrupts=0); 
-  
+  void update(bool interrupts=0);
+
   /**
    * gw.poll(); needs to be called to handle incoming data from the network interface.
    * The function will perform a delayed wait of max 3ms unless otherwise specified.
    * @param waitDelay How long in milliseconds this function will wait for incoming data.
    */
-  void poll(uint32_t waitDelay=3); 
-  
+  void poll(uint32_t waitDelay=3);
+
   /**
   * When using interrupts (gwNodeInt, ncursesInt examples) users need to call
   * this function to disable interrupts before accessing the radio and again to
   * re-enable interrupts when complete
   * @param enable 0 to disable interrupts and access the radio, 1 to re-enable
   */
-  
+
   void interrupts(bool enable = 1);
-  
+
     /**@}*/
     /**
      * @name Advanced Operation
      *
      *  More advanced methods and options
      */
-    /**@{*/  
-  
+    /**@{*/
+
   uint16_t thisNodeAddress; /**< Address of our node in Octal format (01,021, etc) */
   uint8_t thisNodeID;  /**< NodeID (0-255) */
-  
-  
+
+
   bool meshEnabled(); /**< Is RF24Mesh enabled? */
   bool config_TUN; /**< Using a TAP(false) or TUN(true) interface */
   bool fifoCleared;
-  
+
   uint32_t ifDropped(){
     return droppedIncoming;
   }
-    
+
   void sendUDP(uint8_t nodeID,RF24NetworkFrame frame);
-  
+
     /**@}*/
     /**
      * @name Routing Table
      *
      *  Utilizing a routing table to provide complete connectivity
      */
-    /**@{*/  
-    
+    /**@{*/
+
   /**
    * If a user has created a file "routing.txt" in the RF24Gateway working directory, it will be loaded <br>
    * at startup into the routing table. The file should contain standard routing table entries as follows: <br>
@@ -169,7 +168,7 @@ public:
    * Data can be accessed using standard linux Internet address manipulation routines as follows:
    * @code
    * printf("**IP\t\tMask\t\tGateway**\n");
-   * for(int i=0; i<gw.routingTableSize; i++){      
+   * for(int i=0; i<gw.routingTableSize; i++){
    *   printf("%s \t",inet_ntoa(gw.routingStruct[i].ip));//inet_ntoa uses a statically assigned buffer, so the printf calls need to be done separately
    *   printf("%s \t",inet_ntoa(gw.routingStruct[i].mask));
    *   printf("%s\n", inet_ntoa(gw.routingStruct[i].gw));
@@ -187,68 +186,68 @@ public:
       struct in_addr mask;
       struct in_addr gw;
    };
-   
+
    /**
    * The array that holds the routing structure data. See routeStruct
    */
    routeStruct routingStruct[256];
-  
+
   /**
    * The size of the existing routing table loaded into memory. See routeStruct
    */
   uint8_t routingTableSize;
-  
-  
+
+
 private:
   RF24& radio;
   RF24Network& network;
   RF24Mesh& mesh;
-  
+
   bool begin(bool configTUN, bool meshEnable, uint16_t address, uint8_t mesh_nodeID, rf24_datarate_e data_rate, uint8_t _channel);
   bool mesh_enabled;
-  
+
   uint32_t droppedIncoming;
-  
+
   uint8_t channel;
   rf24_datarate_e dataRate;
   char tunName[IFNAMSIZ];
   int tunFd;
-  
+
   unsigned long packets_sent;  /**< How many have we sent already */
   uint32_t interfaceInTimer;
-  
+
   void handleRadioOut();
   void handleRadioIn();
   void handleRX(uint32_t waitDelay=0);
   void handleTX();
   volatile bool interruptInProgress;
   volatile bool interruptsEnabled;
-   
-  int configDevice(uint16_t address);  
+
+  int configDevice(uint16_t address);
   int allocateTunDevice(char *dev, int flags, uint16_t address);
-  
+
   struct msgStruct{
     std::uint8_t message[MAX_PAYLOAD_SIZE];
 	std::size_t size;
   };
-  
+
   std::queue<msgStruct>rxQueue;
   std::queue<msgStruct>txQueue;
-  
+
   void printPayload(std::string buffer, std::string debugMsg = "");
   void printPayload(char *buffer, int nread, std::string debugMsg = "");
-  
+
   int s;  //Socket variable for sending UDP
   void setupSocket();
   struct sockaddr_in addr;
   struct in_addr getLocalIP();
-  
+
   void loadRoutingTable();
-  
+
 };
-  
-  
-  
+
+
+
 
 /**
  * @example RF24GatewayNode.cpp
@@ -256,13 +255,13 @@ private:
  * A simple example of using RF24Gateway node to forward IP traffic automatically to a network interface, while
  * managing standard RF24Network user payloads independently.
  */
- 
+
  /**
  * @example RF24Gateway_ncurses.cpp
  *
  * RF24Gateway NCurses interface - TMRh20 2015 <br>
  * This is a generic tool for nodes supporting or combining with RF24Ethernet and/or RF24Network.
- * 
+ *
  * The tool provides a simple interface for monitoring information and activity regarding the RF24Gateway: <br>
  * a: Interface statistics from /proc/net/dev <br>
  * b: RF24Mesh address/id assignments <br>
@@ -275,25 +274,25 @@ private:
  *
  * @image html ncurses.JPG
  */
- 
+
  /**
  * @example RF24GatewayNodeInt.cpp
  *
  * A copy of the RF24GatewayNode example using interrupts.
  */
- 
+
  /**
  * @example RF24Gateway_ncursesInt.cpp
  *
  * A copy of the ncurses example using interrupts.
  */
- 
+
  /** @example bClient.sh
  *
  * Once RF24Gateway and RF24Ethernet are configured, standard tools can be used to interact with
  * the sensor nodes. <br>Example of on demand LED/Lighting control using a Bash script.
  */
- 
+
  /** @example nodeClient.js
  *
  * Once RF24Gateway and RF24Ethernet are configured, standard tools can be used to interact with
@@ -305,7 +304,7 @@ private:
  * Once RF24Gateway and RF24Ethernet are configured, standard tools can be used to interact with
  * the sensor nodes. <br> Example of scheduled LED/Lighting control using a Python script.
  */
- 
+
 /**
  * @mainpage RF24Gateway
  *
@@ -319,13 +318,13 @@ private:
  * @section Installation Installation
  *
  * See http://tmrh20.github.io/RF24 for installation instructions using the installer, or clone the RF24 libs and run 'make install' for each one.
- * 
+ *
  * After running the installer, RF24Gateway will be installed at rf24libs/RF24Gateway. <b><a href="examples.html">Examples</a></b> are included for operating the gateway
  * as well as client scripts & programs to control nodes via http requests.
  *
  * Note: RF24Gateway is tested with and defaults to using RF24Mesh. Sensor nodes must also use RF24Mesh or be statically assigned within RF24Mesh.
  *
- * See http://tmrh20.github.io/RF24Ethernet/ for related documentation for use with RF24Gateway. 
+ * See http://tmrh20.github.io/RF24Ethernet/ for related documentation for use with RF24Gateway.
  *
  * @section HowItWorks How It Works
  *
@@ -339,9 +338,9 @@ private:
  *
  *
  * @section SimpleConfig Simple Configuration
- * 
- * In the standard configuration, a single Linux/RF24Gateway node is used to provide connectivity to one or more 
- * Arduino nodes running RF24Ethernet. 
+ *
+ * In the standard configuration, a single Linux/RF24Gateway node is used to provide connectivity to one or more
+ * Arduino nodes running RF24Ethernet.
  * In this case the master node could be configured with IP 10.1.3.1 netmask 255.255.255.0 and nodeID 0
  * The remaining Arduino nodes can used nodeIDs 2-253, and would be assigned IP addresses 10.1.3.2-253 and netmask 255.255.255.0
  *
@@ -366,15 +365,15 @@ private:
  * In this case the master node could be configured differently with IP 10.1.3.1 netmask 255.255.0.0 and nodeID 0
  * The child RPi2 node could be assigned IP 10.1.3.33 netmask 255.255.0.0 and nodeID 33
  * Another device, lets say usb0 connected to the child RPi2 node is assigned IP 10.1.5.1 netmask 255.255.255.0
- * 
+ *
  * In this configuration, connectivity between all nodes in the mesh would be established, but a routing table is
  * needed to include attached and internet devices.
- * 
+ *
  * To fully enable routing beyond the RPi devices, a routing table needs to be added to the Master node:
  * 1. Rename the file RF24Gateway/examples/routing.txx to routing.txt
  * 2. Edit the file accordingly
  * 3. Restart the gateway example to reload routing info
- * 
+ *
  * @section NetCfg Network Configuration Example
  * Local WiFi/Ethernet Network (Windows,Linux,RPi devices etc) - 10.10.1.0 - 255.255.255.0 ( 10.10.1.x network ) <br>
  * RPi devices (tun_nrf24 interfaces & all connected devices) - 10.1.0.0 - 255.255.0.0 ( 10.1.x.x network )<br>
@@ -389,19 +388,19 @@ private:
  * In the RF24Gateway example working directory, create a file "routing.txt" <br>
  * Add routing entries in a standard kind of format: <br>
  * ie: IP<space>NetMask<space>Gateway <br>
- * Example routing.txt file: 
- * 
+ * Example routing.txt file:
+ *
  * 10.1.5.0 255.255.255.0 10.1.3.33 <br>
  * 10.1.4.0 255.255.255.0 10.1.3.34 <br>
  * 0.0.0.0 0.0.0.0 10.10.3.33 <br>
  *
  * First entry: Traffic for 10.1.5.x will use 10.1.3.33 as the gateway <br>
  * 2nd entry: Traffic for 10.1.4.x will use 10.1.3.34 as the gateway <br>
- * 3rd entry: Traffic not in the RF24Gateway network will be sent via 10.10.3.33 by default 
- * 
+ * 3rd entry: Traffic not in the RF24Gateway network will be sent via 10.10.3.33 by default
+ *
  * Additional Routing Configuration:<br>
  * You can specify any combination of IP/Netmask in the routing.txt file to create unique subnets for routing traffic:
- * 
+ *
  * 10.1.5.0 255.255.255.224 10.1.3.33 <br>
  * 10.1.5.32 255.255.255.224 10.1.3.34 <br>
  * 10.1.5.64 255.255.255.224 10.1.3.35 <br>
@@ -411,10 +410,10 @@ private:
  * 2nd entry: Traffic for 10.1.5.(33-62) will use 10.1.3.34 as the gateway <br>
  * 3rd entry: Traffic for 10.1.5.(65-94) will use 10.1.3.35 as the gateway <br>
  * 3rd entry: Traffic not in the RF24Gateway network will be sent via 10.10.3.32 by default <br>
- * 
+ *
  *
  *
  */
- 
- 
+
+
  #endif

--- a/Readme.md
+++ b/Readme.md
@@ -8,10 +8,10 @@ RF24Ethernet allows small Arduino/AVR devices to communicate using TCP/IP over n
 RF24Gateway allows a RPi/Linux device to act as a gateway for those nodes, handling IP traffic automatically, while allowing users
 to utilize standard RF24Network messages as well.
 
-**Documentation:** 
+**Documentation:**
 
-http://tmrh20.github.io/RF24Gateway  
+http://nRF24.github.io/RF24Gateway
 
-http://tmrh20.github.io/RF24Ethernet  
+http://nRF24.github.io/RF24Ethernet
 
 All: http://tmrh20.github.io

--- a/doxygen-custom.css
+++ b/doxygen-custom.css
@@ -1,295 +1,295 @@
 /* The standard CSS for doxygen */
 
 body, table, div, p, dl {
-	font-family: Lucida Grande, Verdana, Geneva, Arial, sans-serif;
-	font-size: 12px;
+    font-family: Lucida Grande, Verdana, Geneva, Arial, sans-serif;
+    font-size: 12px;
 }
 
 /* @group Heading Levels */
 
 h1 {
-	font-size: 150%;
+    font-size: 150%;
 }
 
 .title {
-	font-size: 150%;
-	font-weight: bold;
-	margin: 10px 2px;
+    font-size: 150%;
+    font-weight: bold;
+    margin: 10px 2px;
 }
 
 h2 {
-	font-size: 120%;
+    font-size: 120%;
 }
 
 h3 {
-	font-size: 100%;
+    font-size: 100%;
 }
 
 dt {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 div.multicol {
-	-moz-column-gap: 1em;
-	-webkit-column-gap: 1em;
-	-moz-column-count: 3;
-	-webkit-column-count: 3;
+    -moz-column-gap: 1em;
+    -webkit-column-gap: 1em;
+    -moz-column-count: 3;
+    -webkit-column-count: 3;
 }
 
 p.startli, p.startdd, p.starttd {
-	margin-top: 2px;
+    margin-top: 2px;
 }
 
 p.endli {
-	margin-bottom: 0px;
+    margin-bottom: 0px;
 }
 
 p.enddd {
-	margin-bottom: 4px;
+    margin-bottom: 4px;
 }
 
 p.endtd {
-	margin-bottom: 2px;
+    margin-bottom: 2px;
 }
 
 /* @end */
 
 caption {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 span.legend {
-        font-size: 70%;
-        text-align: center;
+    font-size: 70%;
+    text-align: center;
 }
 
 h3.version {
-        font-size: 90%;
-        text-align: center;
+    font-size: 90%;
+    text-align: center;
 }
 
-div.qindex, div.navtab{
-	background-color: #EBEFF6;
-	border: 1px solid #A3B4D7;
-	text-align: center;
-	margin: 2px;
-	padding: 2px;
+div.qindex, div.navtab {
+    background-color: #EBEFF6;
+    border: 1px solid #A3B4D7;
+    text-align: center;
+    margin: 2px;
+    padding: 2px;
 }
 
 div.qindex, div.navpath {
-	width: 100%;
-	line-height: 110%;
+    width: 100%;
+    line-height: 110%;
 }
 
 div.navtab {
-	margin-right: 15px;
+    margin-right: 15px;
 }
 
 /* @group Link Styling */
 
 a {
-	color: #3D578C;
-	font-weight: normal;
-	text-decoration: none;
+    color: #3D578C;
+    font-weight: normal;
+    text-decoration: none;
 }
 
 .contents a:visited {
-	color: #4665A2;
+    color: #4665A2;
 }
 
 a:hover {
-	text-decoration: underline;
+    text-decoration: underline;
 }
 
 a.qindex {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 a.qindexHL {
-	font-weight: bold;
-	background-color: #9CAFD4;
-	color: #ffffff;
-	border: 1px double #869DCA;
+    font-weight: bold;
+    background-color: #9CAFD4;
+    color: #ffffff;
+    border: 1px double #869DCA;
 }
 
 .contents a.qindexHL:visited {
-        color: #ffffff;
+    color: #ffffff;
 }
 
 a.el {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 a.elRef {
 }
 
 a.code {
-	color: #4665A2;
+    color: #4665A2;
 }
 
 a.codeRef {
-	color: #4665A2;
+    color: #4665A2;
 }
 
 /* @end */
 
 dl.el {
-	margin-left: -1cm;
+    margin-left: -1cm;
 }
 
 .fragment {
-	font-family: monospace, fixed;
-	font-size: 105%;
+    font-family: monospace, fixed;
+    font-size: 105%;
 }
 
 pre.fragment {
-	border: 1px solid #C4CFE5;
-	background-color: #FBFCFD;
-	padding: 4px 6px;
-	margin: 4px 8px 4px 2px;
-	overflow: auto;
-	word-wrap: break-word;
-	font-size:  9pt;
-	line-height: 125%;
+    border: 1px solid #C4CFE5;
+    background-color: #FBFCFD;
+    padding: 4px 6px;
+    margin: 4px 8px 4px 2px;
+    overflow: auto;
+    word-wrap: break-word;
+    font-size: 9pt;
+    line-height: 125%;
 }
 
 div.ah {
-	background-color: black;
-	font-weight: bold;
-	color: #ffffff;
-	margin-bottom: 3px;
-	margin-top: 3px;
-	padding: 0.2em;
-	border: solid thin #333;
-	border-radius: 0.5em;
-	-webkit-border-radius: .5em;
-	-moz-border-radius: .5em;
-	box-shadow: 2px 2px 3px #999;
-	-webkit-box-shadow: 2px 2px 3px #999;
-	-moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
-	background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000),color-stop(0.3, #444));
-	background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000);
+    background-color: black;
+    font-weight: bold;
+    color: #ffffff;
+    margin-bottom: 3px;
+    margin-top: 3px;
+    padding: 0.2em;
+    border: solid thin #333;
+    border-radius: 0.5em;
+    -webkit-border-radius: .5em;
+    -moz-border-radius: .5em;
+    box-shadow: 2px 2px 3px #999;
+    -webkit-box-shadow: 2px 2px 3px #999;
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000), color-stop(0.3, #444));
+    background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000);
 }
 
 div.groupHeader {
-	margin-left: 16px;
-	margin-top: 12px;
-	font-weight: bold;
+    margin-left: 16px;
+    margin-top: 12px;
+    font-weight: bold;
 }
 
 div.groupText {
-	margin-left: 16px;
-	font-style: italic;
+    margin-left: 16px;
+    font-style: italic;
 }
 
 body {
-	background: white;
-	color: black;
-        margin: 0;
+    background: white;
+    color: black;
+    margin: 0;
 }
 
 div.contents {
-	margin-top: 10px;
-	margin-left: 10px;
-	margin-right: 5px;
+    margin-top: 10px;
+    margin-left: 10px;
+    margin-right: 5px;
 }
 
 td.indexkey {
-	background-color: #EBEFF6;
-	font-weight: bold;
-	border: 1px solid #C4CFE5;
-	margin: 2px 0px 2px 0;
-	padding: 2px 10px;
+    background-color: #EBEFF6;
+    font-weight: bold;
+    border: 1px solid #C4CFE5;
+    margin: 2px 0px 2px 0;
+    padding: 2px 10px;
 }
 
 td.indexvalue {
-	background-color: #EBEFF6;
-	border: 1px solid #C4CFE5;
-	padding: 2px 10px;
-	margin: 2px 0px;
+    background-color: #EBEFF6;
+    border: 1px solid #C4CFE5;
+    padding: 2px 10px;
+    margin: 2px 0px;
 }
 
 tr.memlist {
-	background-color: #EEF1F7;
+    background-color: #EEF1F7;
 }
 
 p.formulaDsp {
-	text-align: center;
+    text-align: center;
 }
 
 img.formulaDsp {
-	
+
 }
 
 img.formulaInl {
-	vertical-align: middle;
+    vertical-align: middle;
 }
 
 div.center {
-	text-align: center;
-        margin-top: 0px;
-        margin-bottom: 0px;
-        padding: 0px;
+    text-align: center;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding: 0px;
 }
 
 div.center img {
-	border: 0px;
+    border: 0px;
 }
 
 address.footer {
-	text-align: right;
-	padding-right: 12px;
+    text-align: right;
+    padding-right: 12px;
 }
 
 img.footer {
-	border: 0px;
-	vertical-align: middle;
+    border: 0px;
+    vertical-align: middle;
 }
 
 /* @group Code Colorization */
 
 span.keyword {
-	color: #008000
+    color: #008000
 }
 
 span.keywordtype {
-	color: #604020
+    color: #604020
 }
 
 span.keywordflow {
-	color: #e08000
+    color: #e08000
 }
 
 span.comment {
-	color: #800000
+    color: #800000
 }
 
 span.preprocessor {
-	color: #806020
+    color: #806020
 }
 
 span.stringliteral {
-	color: #002080
+    color: #002080
 }
 
 span.charliteral {
-	color: #008080
+    color: #008080
 }
 
-span.vhdldigit { 
-	color: #ff00ff 
+span.vhdldigit {
+    color: #ff00ff
 }
 
-span.vhdlchar { 
-	color: #000000 
+span.vhdlchar {
+    color: #000000
 }
 
-span.vhdlkeyword { 
-	color: #700070 
+span.vhdlkeyword {
+    color: #700070
 }
 
-span.vhdllogic { 
-	color: #ff0000 
+span.vhdllogic {
+    color: #ff0000
 }
 
 /* @end */
@@ -314,66 +314,66 @@ input.search {
 */
 
 td.tiny {
-	font-size: 75%;
+    font-size: 75%;
 }
 
 .dirtab {
-	padding: 4px;
-	border-collapse: collapse;
-	border: 1px solid #A3B4D7;
+    padding: 4px;
+    border-collapse: collapse;
+    border: 1px solid #A3B4D7;
 }
 
 th.dirtab {
-	background: #EBEFF6;
-	font-weight: bold;
+    background: #EBEFF6;
+    font-weight: bold;
 }
 
 hr {
-	height: 0px;
-	border: none;
-	border-top: 1px solid #4A6AAA;
+    height: 0px;
+    border: none;
+    border-top: 1px solid #4A6AAA;
 }
 
 hr.footer {
-	height: 1px;
+    height: 1px;
 }
 
 /* @group Member Descriptions */
 
 table.memberdecls {
-	border-spacing: 0px;
-	padding: 0px;
+    border-spacing: 0px;
+    padding: 0px;
 }
 
 .mdescLeft, .mdescRight,
 .memItemLeft, .memItemRight,
 .memTemplItemLeft, .memTemplItemRight, .memTemplParams {
-	background-color: #F9FAFC;
-	border: none;
-	margin: 4px;
-	padding: 1px 0 0 8px;
+    background-color: #F9FAFC;
+    border: none;
+    margin: 4px;
+    padding: 1px 0 0 8px;
 }
 
 .mdescLeft, .mdescRight {
-	padding: 0px 8px 4px 8px;
-	color: #555;
+    padding: 0px 8px 4px 8px;
+    color: #555;
 }
 
 .memItemLeft, .memItemRight, .memTemplParams {
-	border-top: 1px solid #C4CFE5;
+    border-top: 1px solid #C4CFE5;
 }
 
 .memItemLeft, .memTemplItemLeft {
-        white-space: nowrap;
+    white-space: nowrap;
 }
 
 .memItemRight {
-	width: 100%;
+    width: 100%;
 }
 
 .memTemplParams {
-	color: #4665A2;
-        white-space: nowrap;
+    color: #4665A2;
+    white-space: nowrap;
 }
 
 /* @end */
@@ -383,122 +383,121 @@ table.memberdecls {
 /* Styles for detailed member documentation */
 
 .memtemplate {
-	font-size: 80%;
-	color: #4665A2;
-	font-weight: normal;
-	margin-left: 9px;
+    font-size: 80%;
+    color: #4665A2;
+    font-weight: normal;
+    margin-left: 9px;
 }
 
 .memnav {
-	background-color: #EBEFF6;
-	border: 1px solid #A3B4D7;
-	text-align: center;
-	margin: 2px;
-	margin-right: 15px;
-	padding: 2px;
+    background-color: #EBEFF6;
+    border: 1px solid #A3B4D7;
+    text-align: center;
+    margin: 2px;
+    margin-right: 15px;
+    padding: 2px;
 }
 
 .mempage {
-	width: 100%;
+    width: 100%;
 }
 
 .memitem {
-	padding: 0;
-	margin-bottom: 10px;
-	margin-right: 5px;
+    padding: 0;
+    margin-bottom: 10px;
+    margin-right: 5px;
 }
 
 .memname {
-        white-space: nowrap;
-        font-weight: bold;
-        margin-left: 6px;
+    white-space: nowrap;
+    font-weight: bold;
+    margin-left: 6px;
 }
 
 .memproto {
-        border-top: 1px solid #A8B8D9;
-        border-left: 1px solid #A8B8D9;
-        border-right: 1px solid #A8B8D9;
-        padding: 6px 0px 6px 0px;
-        color: #253555;
-        font-weight: bold;
-        text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
-        /* opera specific markup */
-        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        border-top-right-radius: 8px;
-        border-top-left-radius: 8px;
-        /* firefox specific markup */
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
-        -moz-border-radius-topright: 8px;
-        -moz-border-radius-topleft: 8px;
-        /* webkit specific markup */
-        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        -webkit-border-top-right-radius: 8px;
-        -webkit-border-top-left-radius: 8px;
-        background-image:url('nav_f.png');
-        background-repeat:repeat-x;
-        background-color: #E2E8F2;
+    border-top: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    padding: 6px 0px 6px 0px;
+    color: #253555;
+    font-weight: bold;
+    text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+    /* opera specific markup */
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    border-top-right-radius: 8px;
+    border-top-left-radius: 8px;
+    /* firefox specific markup */
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+    -moz-border-radius-topright: 8px;
+    -moz-border-radius-topleft: 8px;
+    /* webkit specific markup */
+    -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    -webkit-border-top-right-radius: 8px;
+    -webkit-border-top-left-radius: 8px;
+    background-image: url('nav_f.png');
+    background-repeat: repeat-x;
+    background-color: #E2E8F2;
 
 }
 
 .memdoc {
-        border-bottom: 1px solid #A8B8D9;      
-        border-left: 1px solid #A8B8D9;      
-        border-right: 1px solid #A8B8D9; 
-        padding: 2px 5px;
-        background-color: #FBFCFD;
-        border-top-width: 0;
-        /* opera specific markup */
-        border-bottom-left-radius: 8px;
-        border-bottom-right-radius: 8px;
-        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        /* firefox specific markup */
-        -moz-border-radius-bottomleft: 8px;
-        -moz-border-radius-bottomright: 8px;
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
-        background-image: -moz-linear-gradient(center top, #FFFFFF 0%, #FFFFFF 60%, #F7F8FB 95%, #EEF1F7);
-        /* webkit specific markup */
-        -webkit-border-bottom-left-radius: 8px;
-        -webkit-border-bottom-right-radius: 8px;
-        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        background-image: -webkit-gradient(linear,center top,center bottom,from(#FFFFFF), color-stop(0.6,#FFFFFF), color-stop(0.60,#FFFFFF), color-stop(0.95,#F7F8FB), to(#EEF1F7));
+    border-bottom: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    padding: 2px 5px;
+    background-color: #FBFCFD;
+    border-top-width: 0;
+    /* opera specific markup */
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    /* firefox specific markup */
+    -moz-border-radius-bottomleft: 8px;
+    -moz-border-radius-bottomright: 8px;
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+    background-image: -moz-linear-gradient(center top, #FFFFFF 0%, #FFFFFF 60%, #F7F8FB 95%, #EEF1F7);
+    /* webkit specific markup */
+    -webkit-border-bottom-left-radius: 8px;
+    -webkit-border-bottom-right-radius: 8px;
+    -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    background-image: -webkit-gradient(linear, center top, center bottom, from(#FFFFFF), color-stop(0.6, #FFFFFF), color-stop(0.60, #FFFFFF), color-stop(0.95, #F7F8FB), to(#EEF1F7));
 }
 
 .paramkey {
-	text-align: right;
+    text-align: right;
 }
 
 .paramtype {
-	white-space: nowrap;
+    white-space: nowrap;
 }
 
 .paramname {
-	color: #602020;
-	white-space: nowrap;
+    color: #602020;
+    white-space: nowrap;
 }
+
 .paramname em {
-	font-style: normal;
+    font-style: normal;
 }
 
 .params, .retval, .exception, .tparams {
-        border-spacing: 6px 2px;
-}       
+    border-spacing: 6px 2px;
+}
 
 .params .paramname, .retval .paramname {
-        font-weight: bold;
-        vertical-align: top;
+    font-weight: bold;
+    vertical-align: top;
 }
-        
+
 .params .paramtype {
-        font-style: italic;
-        vertical-align: top;
-}       
-        
-.params .paramdir {
-        font-family: "courier new",courier,monospace;
-        vertical-align: top;
+    font-style: italic;
+    vertical-align: top;
 }
 
-
+.params .paramdir {
+    font-family: "courier new", courier, monospace;
+    vertical-align: top;
+}
 
 
 /* @end */
@@ -508,22 +507,22 @@ table.memberdecls {
 /* for the tree view */
 
 .ftvtree {
-	font-family: sans-serif;
-	margin: 0px;
+    font-family: sans-serif;
+    margin: 0px;
 }
 
 /* these are for tree view when used as main index */
 
 .directory {
-	font-size: 9pt;
-	font-weight: bold;
-	margin: 5px;
+    font-size: 9pt;
+    font-weight: bold;
+    margin: 5px;
 }
 
 .directory h3 {
-	margin: 0px;
-	margin-top: 1em;
-	font-size: 11pt;
+    margin: 0px;
+    margin-top: 1em;
+    font-size: 11pt;
 }
 
 /*
@@ -545,291 +544,272 @@ proper pixel height of your image.
 */
 
 .directory > h3 {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 .directory p {
-	margin: 0px;
-	white-space: nowrap;
+    margin: 0px;
+    white-space: nowrap;
 }
 
 .directory div {
-	display: none;
-	margin: 0px;
+    display: none;
+    margin: 0px;
 }
 
 .directory img {
-	vertical-align: -30%;
+    vertical-align: -30%;
 }
 
 /* these are for tree view when not used as main index */
 
 .directory-alt {
-	font-size: 100%;
-	font-weight: bold;
+    font-size: 100%;
+    font-weight: bold;
 }
 
 .directory-alt h3 {
-	margin: 0px;
-	margin-top: 1em;
-	font-size: 11pt;
+    margin: 0px;
+    margin-top: 1em;
+    font-size: 11pt;
 }
 
 .directory-alt > h3 {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 .directory-alt p {
-	margin: 0px;
-	white-space: nowrap;
+    margin: 0px;
+    white-space: nowrap;
 }
 
 .directory-alt div {
-	display: none;
-	margin: 0px;
+    display: none;
+    margin: 0px;
 }
 
 .directory-alt img {
-	vertical-align: -30%;
+    vertical-align: -30%;
 }
 
 /* @end */
 
 div.dynheader {
-        margin-top: 8px;
+    margin-top: 8px;
 }
 
 address {
-	font-style: normal;
-	color: #2A3D61;
+    font-style: normal;
+    color: #2A3D61;
 }
 
 table.doxtable {
-	border-collapse:collapse;
+    border-collapse: collapse;
 }
 
 table.doxtable td, table.doxtable th {
-	border: 1px solid #2D4068;
-	padding: 3px 7px 2px;
+    border: 1px solid #2D4068;
+    padding: 3px 7px 2px;
 }
 
 table.doxtable th {
-	background-color: #374F7F;
-	color: #FFFFFF;
-	font-size: 110%;
-	padding-bottom: 4px;
-	padding-top: 5px;
-	text-align:left;
+    background-color: #374F7F;
+    color: #FFFFFF;
+    font-size: 110%;
+    padding-bottom: 4px;
+    padding-top: 5px;
+    text-align: left;
 }
 
 .tabsearch {
-	top: 0px;
-	left: 10px;
-	height: 36px;
-	background-image: url('tab_b.png');
-	z-index: 101;
-	overflow: hidden;
-	font-size: 13px;
+    top: 0px;
+    left: 10px;
+    height: 36px;
+    background-image: url('tab_b.png');
+    z-index: 101;
+    overflow: hidden;
+    font-size: 13px;
 }
 
-.navpath ul
-{
-	font-size: 11px;
-	background-image:url('tab_b.png');
-	background-repeat:repeat-x;
-	height:30px;
-	line-height:30px;
-	color:#8AA0CC;
-	border:solid 1px #C2CDE4;
-	overflow:hidden;
-	margin:0px;
-	padding:0px;
+.navpath ul {
+    font-size: 11px;
+    background-image: url('tab_b.png');
+    background-repeat: repeat-x;
+    height: 30px;
+    line-height: 30px;
+    color: #8AA0CC;
+    border: solid 1px #C2CDE4;
+    overflow: hidden;
+    margin: 0px;
+    padding: 0px;
 }
 
-.navpath li
-{
-	list-style-type:none;
-	float:left;
-	padding-left:10px;
-	padding-right:15px;
-	background-image:url('bc_s.png');
-	background-repeat:no-repeat;
-	background-position:right;
-	color:#364D7C;
+.navpath li {
+    list-style-type: none;
+    float: left;
+    padding-left: 10px;
+    padding-right: 15px;
+    background-image: url('bc_s.png');
+    background-repeat: no-repeat;
+    background-position: right;
+    color: #364D7C;
 }
 
-.navpath li.navelem a
-{
-	height:32px;
-	display:block;
-	text-decoration: none;
-	outline: none;
+.navpath li.navelem a {
+    height: 32px;
+    display: block;
+    text-decoration: none;
+    outline: none;
 }
 
-.navpath li.navelem a:hover
-{
-	color:#6884BD;
+.navpath li.navelem a:hover {
+    color: #6884BD;
 }
 
-.navpath li.footer
-{
-        list-style-type:none;
-        float:right;
-        padding-left:10px;
-        padding-right:15px;
-        background-image:none;
-        background-repeat:no-repeat;
-        background-position:right;
-        color:#364D7C;
-        font-size: 8pt;
+.navpath li.footer {
+    list-style-type: none;
+    float: right;
+    padding-left: 10px;
+    padding-right: 15px;
+    background-image: none;
+    background-repeat: no-repeat;
+    background-position: right;
+    color: #364D7C;
+    font-size: 8pt;
 }
 
 
-div.summary
-{
-	float: right;
-	font-size: 8pt;
-	padding-right: 5px;
-	width: 50%;
-	text-align: right;
-}       
-
-div.summary a
-{
-	white-space: nowrap;
+div.summary {
+    float: right;
+    font-size: 8pt;
+    padding-right: 5px;
+    width: 50%;
+    text-align: right;
 }
 
-div.ingroups
-{
-	font-size: 8pt;
-	padding-left: 5px;
-	width: 50%;
-	text-align: left;
+div.summary a {
+    white-space: nowrap;
 }
 
-div.ingroups a
-{
-	white-space: nowrap;
+div.ingroups {
+    font-size: 8pt;
+    padding-left: 5px;
+    width: 50%;
+    text-align: left;
 }
 
-div.header
-{
-        background-image:url('nav_h.png');
-        background-repeat:repeat-x;
-	background-color: #F9FAFC;
-	margin:  0px;
-	border-bottom: 1px solid #C4CFE5;
+div.ingroups a {
+    white-space: nowrap;
 }
 
-div.headertitle
-{
-	padding: 5px 5px 5px 10px;
+div.header {
+    background-image: url('nav_h.png');
+    background-repeat: repeat-x;
+    background-color: #F9FAFC;
+    margin: 0px;
+    border-bottom: 1px solid #C4CFE5;
 }
 
-dl
-{
-        padding: 0 0 0 10px;
+div.headertitle {
+    padding: 5px 5px 5px 10px;
 }
 
-dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug
-{
-        border-left:4px solid;
-        padding: 0 0 0 6px;
+dl {
+    padding: 0 0 0 10px;
 }
 
-dl.note
-{
-        border-color: #D0C000;
+dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug {
+    border-left: 4px solid;
+    padding: 0 0 0 6px;
 }
 
-dl.warning, dl.attention
-{
-        border-color: #FF0000;
+dl.note {
+    border-color: #D0C000;
 }
 
-dl.pre, dl.post, dl.invariant
-{
-        border-color: #00D000;
+dl.warning, dl.attention {
+    border-color: #FF0000;
 }
 
-dl.deprecated
-{
-        border-color: #505050;
+dl.pre, dl.post, dl.invariant {
+    border-color: #00D000;
 }
 
-dl.todo
-{
-        border-color: #00C0E0;
+dl.deprecated {
+    border-color: #505050;
 }
 
-dl.test
-{
-        border-color: #3030E0;
+dl.todo {
+    border-color: #00C0E0;
 }
 
-dl.bug
-{
-        border-color: #C08050;
+dl.test {
+    border-color: #3030E0;
 }
 
-#projectlogo
-{
-	text-align: center;
-	vertical-align: bottom;
-	border-collapse: separate;
-}
- 
-#projectlogo img
-{ 
-	border: 0px none;
-}
- 
-#projectname
-{
-	font: 300% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 2px 0px;
-}
-    
-#projectbrief
-{
-	font: 120% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 0px;
+dl.bug {
+    border-color: #C08050;
 }
 
-#projectnumber
-{
-	font: 50% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 0px;
+#projectlogo {
+    text-align: center;
+    vertical-align: bottom;
+    border-collapse: separate;
 }
 
-#titlearea
-{
-	padding: 0px;
-	margin: 0px;
-	width: 100%;
-	border-bottom: 1px solid #5373B4;
+#projectlogo img {
+    border: 0px none;
 }
 
-.image
-{
-        text-align: left;
+#projectname {
+    font: 300% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 2px 0px;
 }
 
-.dotgraph
-{
-        text-align: center;
+#projectbrief {
+    font: 120% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 0px;
 }
 
-.mscgraph
-{
-        text-align: center;
+#projectnumber {
+    font: 50% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 0px;
 }
 
-.caption
-{
-	font-weight: bold;
+#titlearea {
+    padding: 0px;
+    margin: 0px;
+    width: 100%;
+    border-bottom: 1px solid #5373B4;
 }
 
+.image {
+    text-align: left;
+}
+
+.dotgraph {
+    text-align: center;
+}
+
+.mscgraph {
+    text-align: center;
+}
+
+.caption {
+    font-weight: bold;
+}
+td.fielddoc
+th.markdownTableHeadLeft,
+th.markdownTableHeadRight,
+th.markdownTableHeadCenter,
+th.markdownTableHeadNone {
+    background-image: none;
+    border-radius: unset;
+}
+
+td.fielddoc tr:last-child {
+    border-bottom: 1px solid #2D4068;
+}

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -3,5 +3,5 @@ mv ie: routing.txx routing.txt
 
 For more information on usage, see:
 
-http://tmrh20.github.io/RF24Gateway
+http://nRF24.github.io/RF24Gateway
 https://github.com/nRF24/RF24Gateway/issues/12


### PR DESCRIPTION
Introduces a new workflow that:
- only runs on master branch
- only deploys docs on release "publish" or "edit" events
- fetches latest version tag from this repo's releases and uses it to update the Doxyfile's "PROJECT_NUMBER" tag. This tag change is not committed to the Doxyfile, rather it is only used during the workflow.

Additionally, I've
- made fixes for all "addressable" doxygen warnings (`Makefile` is parsed like a C source file because there is no extension -- its a doxygen problem)
    - This includes removing deprecated tags from the Doxyfile (they were using default or invalid options anyway). I didn't use `doxygen -u` for backward compatibility reasons.
- formatted and updated the doxygen-custom.css file
- renamed all links to docs from tmrh20.github.io/\<repo name> to nRF24.github.io/\<repo name> except for:
    - the links to the automatic install/update script at [tmrh20's RF24Installer for RPi](https://github.com/TMRh20/tmrh20.github.io/tree/master/RF24Installer/RPi)
    - any links that lead to tmrh20.github.io main page listing all RF24 repos (links for this page have to be changed separately in the [tmrh20.github.io repo's index.html file](https://github.com/TMRh20/tmrh20.github.io/blob/587d08b7b1cc9185fb6bb1185fbf3f42e1546acd/index.html#L33)
- deactivated any LATEX or XML output from doxygen since they're not actually being used (and the LATEX output seems to require 3rd party software to generate properly). 