### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,165 @@
+# See options listed at https://releases.llvm.org/12.0.1/tools/clang/docs/ClangFormatStyleOptions.html
+---
+Language: Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: Consecutive
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros: ["__capability", "__output", "__ununsed"]
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: MultiLine
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 0
+# CommentPragmas are a regex pattern indicating the comment is not be touched by the formatter
+CommentPragmas: "^ Include gaurd .*"
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: false
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineBeforeAccessModifier: Always
+# ---
+# only in v13+
+# EmptyLineAfterAccessModifier: Leave
+# ---
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: ".*"
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: "(Test)?$"
+IncludeIsMainSourceRegex: ""
+# ---
+# only in v13+
+# IndentAccessModifiers: false
+# ---
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: false
+IndentPPDirectives: BeforeHash
+IndentExternBlock: AfterExternBlock
+IndentRequires: false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+# ---
+# only in v13+
+# ReferenceAlignment: Right
+# ---
+ReflowComments: true
+# ---
+# only in v13+
+# ShortNamespaceLines: 0
+# ---
+# Sort**** is about sorting include/using statements alphabetically
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: c++11
+StatementAttributeLikeMacros: [emit]
+StatementMacros: [Q_UNUSED, QT_REQUIRE_VERSION]
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+  - PRIPSTR
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -28,7 +28,33 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  check_formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      # Ubuntu 20.04.4 LTS reunners ship with clang-tools v12
+      # - name: Install clang-tools
+      #   uses: KyleMayes/install-llvm-action@v1
+      #   with:
+      #     version: 12
+      - name: Install linter python package
+        run: python3 -m pip install git+https://github.com/cpp-linter/cpp-linter-action@v1
+      - name: run linter as a python package
+        id: linter
+        run: |
+          cpp-linter \
+          --version=12 \
+          --style=file \
+          --tidy-checks='-*' \
+          --files-changed-only='False'
+      - name: Linter checks failed?
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1
+
   using_cmake:
+    needs: check_formatting
     runs-on: ubuntu-latest
 
     strategy:

--- a/RF24Gateway.cpp
+++ b/RF24Gateway.cpp
@@ -9,7 +9,7 @@
 
 /***************************************************************************************/
 
-RF24Gateway::RF24Gateway(RF24 &_radio, RF24Network &_network, RF24Mesh &_mesh) : radio(_radio), network(_network), mesh(_mesh)
+RF24Gateway::RF24Gateway(RF24& _radio, RF24Network& _network, RF24Mesh& _mesh) : radio(_radio), network(_network), mesh(_mesh)
 {
     interruptInProgress = 0;
     interruptsEnabled = 1;
@@ -34,10 +34,10 @@ void RF24Gateway::begin(uint16_t address, uint8_t _channel, rf24_datarate_e data
 
 bool RF24Gateway::begin(bool configTUN, bool meshEnable, uint16_t address, uint8_t mesh_nodeID, rf24_datarate_e data_rate, uint8_t _channel)
 {
-    #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
     printf("GW Begin\n");
     printf("Config Device address 0%o nodeID %d\n", address, mesh_nodeID);
-    #endif
+#endif
     config_TUN = configTUN;
 
     ///FIX
@@ -165,7 +165,7 @@ int RF24Gateway::configDevice(uint16_t address)
         flags = IFF_TAP | IFF_NO_PI | IFF_MULTI_QUEUE;
     }
     tunFd = allocateTunDevice(tunName, flags, address);
-    #if DEBUG_LEVEL >= 1
+#if DEBUG_LEVEL >= 1
     if (tunFd >= 0) {
         std::cout << "RF24Gw: Successfully attached to tun/tap device " << tunTapDevice << std::endl;
     }
@@ -173,13 +173,13 @@ int RF24Gateway::configDevice(uint16_t address)
         std::cerr << "RF24Gw: Error allocating tun/tap interface: " << tunFd << std::endl;
         exit(1);
     }
-    #endif
+#endif
     return tunFd;
 }
 
 /***************************************************************************************/
 
-int RF24Gateway::allocateTunDevice(char *dev, int flags, uint16_t address)
+int RF24Gateway::allocateTunDevice(char* dev, int flags, uint16_t address)
 {
     struct ifreq ifr;
     int fd;
@@ -198,7 +198,7 @@ int RF24Gateway::allocateTunDevice(char *dev, int flags, uint16_t address)
     }
 
     // Create device
-    if (ioctl(fd, TUNSETIFF, (void *)&ifr) < 0) {
+    if (ioctl(fd, TUNSETIFF, (void*)&ifr) < 0) {
         //close(fd);
         //#if (DEBUG_LEVEL >= 1)
         std::cerr << "RF24Gw: Error: enabling TUNSETIFF" << std::endl;
@@ -209,29 +209,29 @@ int RF24Gateway::allocateTunDevice(char *dev, int flags, uint16_t address)
 
     //Make persistent
     if (ioctl(fd, TUNSETPERSIST, 1) < 0) {
-        #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
         std::cerr << "RF24Gw: Error: enabling TUNSETPERSIST" << std::endl;
-        #endif
+#endif
         return -1;
     }
 
     if (!config_TUN) {
         struct sockaddr sap;
         sap.sa_family = ARPHRD_ETHER;
-        ((char *)sap.sa_data)[4] = address;
-        ((char *)sap.sa_data)[5] = address >> 8;
-        ((char *)sap.sa_data)[0] = 0x52;
-        ((char *)sap.sa_data)[1] = 0x46;
-        ((char *)sap.sa_data)[2] = 0x32;
-        ((char *)sap.sa_data)[3] = 0x34;
+        ((char*)sap.sa_data)[4] = address;
+        ((char*)sap.sa_data)[5] = address >> 8;
+        ((char*)sap.sa_data)[0] = 0x52;
+        ((char*)sap.sa_data)[1] = 0x46;
+        ((char*)sap.sa_data)[2] = 0x32;
+        ((char*)sap.sa_data)[3] = 0x34;
 
         //printf("Address 0%o first %u last %u\n",address,sap.sa_data[0],sap.sa_data[1]);
-        memcpy((char *)&ifr.ifr_hwaddr, (char *)&sap, sizeof(struct sockaddr));
+        memcpy((char*)&ifr.ifr_hwaddr, (char*)&sap, sizeof(struct sockaddr));
 
         if (ioctl(fd, SIOCSIFHWADDR, &ifr) < 0) {
-            #if DEBUG_LEVEL >= 1
+#if DEBUG_LEVEL >= 1
             fprintf(stderr, "RF24Gw: Failed to set MAC address\n");
-            #endif
+#endif
         }
     }
 
@@ -241,7 +241,7 @@ int RF24Gateway::allocateTunDevice(char *dev, int flags, uint16_t address)
 
 /***************************************************************************************/
 
-int RF24Gateway::setIP(char *ip_addr, char *mask)
+int RF24Gateway::setIP(char* ip_addr, char* mask)
 {
     struct ifreq ifr;
     struct sockaddr_in sin;
@@ -263,13 +263,13 @@ int RF24Gateway::setIP(char *ip_addr, char *mask)
     }
 
 #ifdef ifr_flags
-#define IRFFLAGS ifr_flags
+    #define IRFFLAGS ifr_flags
 #else /* Present on kFreeBSD */
-#define IRFFLAGS ifr_flagshigh
+    #define IRFFLAGS ifr_flagshigh
 #endif
 
     if (!(ifr.IRFFLAGS & IFF_UP)) {
-        //fprintf(stdout, "Device is currently down..setting up.-- %u\n",ifr.IRFFLAGS);
+        //fprintf(stdout, "Device is currently down..setting up.-- %u\n", ifr.IRFFLAGS);
         ifr.IRFFLAGS |= IFF_UP;
         if (ioctl(sockfd, SIOCSIFFLAGS, &ifr) < 0) {
             fprintf(stderr, "ifup: failed ");
@@ -381,7 +381,8 @@ void RF24Gateway::handleRadioIn()
         }
     }
     else {
-        while (network.update()) {}
+        while (network.update()) {
+        }
     }
 
     RF24NetworkFrame f;
@@ -396,10 +397,10 @@ void RF24Gateway::handleRadioIn()
             memcpy(&msg.message, &f.message_buffer, bytesRead);
             msg.size = bytesRead;
 
-            #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
             std::cout << "Radio: Received " << bytesRead << " bytes ... " << std::endl;
-            #endif
-            #if (DEBUG_LEVEL >= 3)
+#endif
+#if (DEBUG_LEVEL >= 3)
             //printPayload(msg.getPayloadStr(),"radio RX");
             std::cout << "TunRead: " << std::endl;
             for (size_t i = 0; i < msg.size; i++) {
@@ -408,7 +409,7 @@ void RF24Gateway::handleRadioIn()
             }
             std::cout << std::endl;
 
-            #endif
+#endif
 
             rxQueue.push(msg);
         }
@@ -463,24 +464,26 @@ void RF24Gateway::handleRadioOut()
 
     while (!txQueue.empty() && network.external_queue.size() == 0) {
 
-        msgStruct *msgTx = &txQueue.front();
+        msgStruct* msgTx = &txQueue.front();
 
-        #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
         std::cout << "Radio: Sending " << msgTx->size << " bytes ... ";
         std::cout << std::endl;
-        #endif
-        #if (DEBUG_LEVEL >= 3)
+#endif
+#if (DEBUG_LEVEL >= 3)
+
         //PrintDebug == 1 does not have an endline.
         //printPayload(msg.getPayloadStr(),"radio TX");
-        #endif
+#endif
 
-        std::uint8_t *tmp = msgTx->message;
+        std::uint8_t* tmp = msgTx->message;
 
         if (!config_TUN) { //TAP can use RF24Mesh for address assignment, but will still use ARP for address resolution
 
             uint32_t RF24_STR = 0x34324652; //Identifies the mac as an RF24 mac
             uint32_t ARP_BC = 0xFFFFFFFF;   //Broadcast address
-            struct macStruct {
+            struct macStruct
+            {
                 uint32_t rf24_Verification;
                 uint16_t rf24_Addr;
             };
@@ -602,17 +605,17 @@ void RF24Gateway::handleRX(uint32_t waitDelay)
         if (FD_ISSET(tunFd, &socketSet)) {
             if ((nread = read(tunFd, buffer, MAX_PAYLOAD_SIZE)) >= 0) {
 
-                #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
                 std::cout << "Tun: Successfully read " << nread << " bytes from tun device" << std::endl;
-                #endif
-                #if (DEBUG_LEVEL >= 3)
+#endif
+#if (DEBUG_LEVEL >= 3)
                 std::cout << "TunRead: " << std::endl;
                 for (int i = 0; i < nread; i++)
                 {
                     printf(":%0x :", buffer[i]);
                 }
                 std::cout << std::endl;
-                #endif
+#endif
                 msgStruct msg;
                 memcpy(&msg.message, &buffer, nread);
                 msg.size = nread;
@@ -624,9 +627,9 @@ void RF24Gateway::handleRX(uint32_t waitDelay)
                 }
             }
             else {
-                #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
                 std::cerr << "Tun: Error while reading from tun/tap interface." << std::endl;
-                #endif
+#endif
             }
         }
     }
@@ -641,7 +644,7 @@ void RF24Gateway::handleTX()
     {
         return;
     }
-    msgStruct *msg = &rxQueue.front();
+    msgStruct* msg = &rxQueue.front();
 
     if (msg->size > MAX_PAYLOAD_SIZE)
     {
@@ -656,26 +659,26 @@ void RF24Gateway::handleTX()
         size_t writtenBytes = write(tunFd, &msg->message, msg->size);
         if (writtenBytes != msg->size)
         {
-            //std::cerr << "Tun: Less bytes written to tun/tap device then requested." << std::endl;
-            #if DEBUG_LEVEL >= 1
+//std::cerr << "Tun: Less bytes written to tun/tap device then requested." << std::endl;
+#if DEBUG_LEVEL >= 1
             printf("Tun: Less bytes written %d to tun/tap device then requested %d.", writtenBytes, msg->size);
-            #endif
+#endif
         }
         else
         {
-            #if (DEBUG_LEVEL >= 1)
+#if (DEBUG_LEVEL >= 1)
             std::cout << "Tun: Successfully wrote " << writtenBytes << " bytes to tun device" << std::endl;
-            #endif
+#endif
         }
 
-        #if (DEBUG_LEVEL >= 3)
+#if (DEBUG_LEVEL >= 3)
         //printPayload(msg.message,"tun write");
         std::cout << "TunRead: " << std::endl;
         for (size_t i = 0; i < msg->size; i++) {
             //printf(":%0x :",msg->message[i]);
         }
         std::cout << std::endl;
-        #endif
+#endif
     }
 
     rxQueue.pop();
@@ -689,7 +692,7 @@ void printPayload(std::string buffer, std::string debugMsg = "")
 
 /***************************************************************************************/
 
-void printPayload(char *buffer, int nread, std::string debugMsg = "")
+void printPayload(char* buffer, int nread, std::string debugMsg = "")
 {
 }
 
@@ -698,7 +701,7 @@ void printPayload(char *buffer, int nread, std::string debugMsg = "")
 void RF24Gateway::setupSocket()
 {
     int ret;
-    const char *myAddr = "127.0.0.1";
+    const char* myAddr = "127.0.0.1";
 
     addr.sin_family = AF_INET;
     ret = inet_aton(myAddr, &addr.sin_addr);
@@ -727,7 +730,7 @@ void RF24Gateway::sendUDP(uint8_t nodeID, RF24NetworkFrame frame)
     memcpy(&buffer[9], &frame.message_size, 2);
     memcpy(&buffer[11], &frame.message_buffer, frame.message_size);
 
-    int ret = sendto(s, &buffer, frame.message_size + 11, 0, (struct sockaddr *)&addr, sizeof(addr));
+    int ret = sendto(s, &buffer, frame.message_size + 11, 0, (struct sockaddr*)&addr, sizeof(addr));
     if (ret == -1)
     {
         perror("sendto");

--- a/RF24Gateway.h
+++ b/RF24Gateway.h
@@ -3,7 +3,6 @@
 #ifndef __RF24GATEWAY_H__
 #define __RF24GATEWAY_H__
 
-
 /**
  * @file RF24Gateway.h
  *
@@ -38,13 +37,14 @@
     #define DEBUG_LEVEL 0
 #endif // DEBUG_LEVEL
 
-#define BACKLOG     10  /* Passed to listen() */
+#define BACKLOG 10 /* Passed to listen() */
 
 class RF24;
 class RF24Network;
 class RF24Mesh;
 
-class RF24Gateway {
+class RF24Gateway
+{
 
     /**
      * @name RF24Gateway (RPi/Linux)
@@ -54,11 +54,10 @@ class RF24Gateway {
     /**@{*/
 
 public:
-
     /**
      * RF24Gateway constructor.
      */
-    RF24Gateway(RF24& _radio,RF24Network& _network, RF24Mesh& _mesh);
+    RF24Gateway(RF24& _radio, RF24Network& _network, RF24Mesh& _mesh);
 
     /**
      * Begin function for use with RF24Mesh (TUN interface)
@@ -70,7 +69,7 @@ public:
      * @code gw.begin(); //Start the gateway using RF24Mesh, with nodeID 0 (Master) @endcode
      * @code uint8_t nodeID; gw.begin(nodeID); //Start the gateway using RF24Mesh, with nodeID 1 (Child node) @endcode
      */
-    void begin(uint8_t nodeID=0, uint8_t channel=97,rf24_datarate_e data_rate=RF24_1MBPS);
+    void begin(uint8_t nodeID = 0, uint8_t channel = 97, rf24_datarate_e data_rate = RF24_1MBPS);
 
     /**
      * Begin function for use with a TAP (Ethernet) interface. RF24Mesh can be used for address assignment, but
@@ -85,7 +84,7 @@ public:
      * @code uint16_t address=00; gw.begin(address); //Start the gateway without using RF24Mesh, with RF24Network address 00 (Master) @endcode
      * @code uint16_t address=01; gw.begin(address); //Start the gateway without using RF24Mesh, with RF24Network address 01 (Child) @endcode
      */
-    void begin(uint16_t address, uint8_t channel=97, rf24_datarate_e data_rate=RF24_1MBPS, bool meshEnable=0, uint8_t nodeID=0 );
+    void begin(uint16_t address, uint8_t channel = 97, rf24_datarate_e data_rate = RF24_1MBPS, bool meshEnable = 0, uint8_t nodeID = 0);
 
     /**
      * Once the Gateway has been started via begin() , call setIP to configure the IP and
@@ -95,7 +94,7 @@ public:
      * @param mask A character array containing the subnet mask ie: 255.255.255.0
      * @return -1 if failed, 0 on success
      */
-    int setIP(char *ip_addr, char *mask);
+    int setIP(char* ip_addr, char* mask);
 
     /**
      * Calling update() keeps the network and mesh layers active and processing data. This needs to be called regularly.
@@ -107,14 +106,14 @@ public:
      * @endcode
      * @param interrupts Set true if called from an interrupt handler & call poll() from the main loop or a thread.
      */
-    void update(bool interrupts=0);
+    void update(bool interrupts = 0);
 
     /**
      * gw.poll(); needs to be called to handle incoming data from the network interface.
      * The function will perform a delayed wait of max 3ms unless otherwise specified.
      * @param waitDelay How long in milliseconds this function will wait for incoming data.
      */
-    void poll(uint32_t waitDelay=3);
+    void poll(uint32_t waitDelay = 3);
 
     /**
      * When using interrupts (gwNodeInt, ncursesInt examples) users need to call
@@ -133,18 +132,18 @@ public:
     /**@{*/
 
     uint16_t thisNodeAddress; /**< Address of our node in Octal format (01,021, etc) */
-    uint8_t thisNodeID;  /**< NodeID (0-255) */
-
+    uint8_t thisNodeID;       /**< NodeID (0-255) */
 
     bool meshEnabled(); /**< Is RF24Mesh enabled? */
-    bool config_TUN; /**< Using a TAP(false) or TUN(true) interface */
+    bool config_TUN;    /**< Using a TAP(false) or TUN(true) interface */
     bool fifoCleared;
 
-    uint32_t ifDropped(){
+    uint32_t ifDropped()
+    {
         return droppedIncoming;
     }
 
-    void sendUDP(uint8_t nodeID,RF24NetworkFrame frame);
+    void sendUDP(uint8_t nodeID, RF24NetworkFrame frame);
 
     /**@}*/
     /**
@@ -182,7 +181,8 @@ public:
      * @endcode
      *
      */
-    struct routeStruct{
+    struct routeStruct
+    {
         struct in_addr ip;
         struct in_addr mask;
         struct in_addr gw;
@@ -197,7 +197,6 @@ public:
      * The size of the existing routing table loaded into memory. See routeStruct
      */
     uint8_t routingTableSize;
-
 
 private:
     RF24& radio;
@@ -214,37 +213,37 @@ private:
     char tunName[IFNAMSIZ];
     int tunFd;
 
-    unsigned long packets_sent;  /**< How many have we sent already */
+    unsigned long packets_sent; /**< How many have we sent already */
     uint32_t interfaceInTimer;
 
     void handleRadioOut();
     void handleRadioIn();
-    void handleRX(uint32_t waitDelay=0);
+    void handleRX(uint32_t waitDelay = 0);
     void handleTX();
     volatile bool interruptInProgress;
     volatile bool interruptsEnabled;
 
     int configDevice(uint16_t address);
-    int allocateTunDevice(char *dev, int flags, uint16_t address);
+    int allocateTunDevice(char* dev, int flags, uint16_t address);
 
-    struct msgStruct{
+    struct msgStruct
+    {
         std::uint8_t message[MAX_PAYLOAD_SIZE];
-    std::size_t size;
+        std::size_t size;
     };
 
-    std::queue<msgStruct>rxQueue;
-    std::queue<msgStruct>txQueue;
+    std::queue<msgStruct> rxQueue;
+    std::queue<msgStruct> txQueue;
 
     void printPayload(std::string buffer, std::string debugMsg = "");
-    void printPayload(char *buffer, int nread, std::string debugMsg = "");
+    void printPayload(char* buffer, int nread, std::string debugMsg = "");
 
-    int s;  //Socket variable for sending UDP
+    int s; //Socket variable for sending UDP
     void setupSocket();
     struct sockaddr_in addr;
     struct in_addr getLocalIP();
 
     void loadRoutingTable();
-
 };
 
 /**

--- a/examples/RF24GatewayNode.cpp
+++ b/examples/RF24GatewayNode.cpp
@@ -10,7 +10,7 @@ RF24Gateway gw(radio, network, mesh);
 
 uint32_t mesh_timer = 0;
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 
     //Config for use with RF24Mesh as Master Node

--- a/examples/gwNodeInt/RF24GatewayNodeInt.cpp
+++ b/examples/gwNodeInt/RF24GatewayNodeInt.cpp
@@ -2,95 +2,92 @@
 
 #include <RF24/RF24.h>
 #include <RF24Network/RF24Network.h>
-#include <RF24Mesh/RF24Mesh.h>  
+#include <RF24Mesh/RF24Mesh.h>
 #include <RF24Gateway/RF24Gateway.h>
 
-//RF24 radio(RPI_V2_GPIO_P1_15, BCM2835_SPI_CS0, BCM2835_SPI_SPEED_8MHZ); 
-RF24 radio(22,0);
+//RF24 radio(RPI_V2_GPIO_P1_15, BCM2835_SPI_CS0, BCM2835_SPI_SPEED_8MHZ);
+RF24 radio(22, 0);
 RF24Network network(radio);
-RF24Mesh mesh(radio,network);
-RF24Gateway gw(radio,network,mesh);
+RF24Mesh mesh(radio, network);
+RF24Gateway gw(radio, network, mesh);
 
-void intHandler(){
-    
+void intHandler()
+{
+
     //Handle RF24Network reads/routing and read/writes of the tun_nrf24 TUN/TAP interface via interrupt
     gw.update(true);
-
 }
 
 uint32_t mesh_timer = 0;
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
 
-  //Config for use with RF24Mesh as Master Node
-  //uint8_t nodeID=0;
-   gw.begin();
+    //Config for use with RF24Mesh as Master Node
+    //uint8_t nodeID=0;
+    gw.begin();
 
-  //Config for use with RF24Mesh as child Node
-  // uint8_t nodeID = 1;
-  // gw.begin(nodeID);
- 
- 
-  //Config for use without RF24Mesh
-  // uint16_t RF24NetworkAddress = 0; 
-  // gw.begin(RF24NetworkAddress);
-  
-  //Set this to your chosen IP/Subnet
-  char ip[] = "10.10.2.2";
-  char subnet[] = "255.255.255.0";
-  
-  gw.setIP(ip,subnet);
-  radio.maskIRQ(1,1,0);
-  attachInterrupt(23, INT_EDGE_FALLING, intHandler);
-  
-  uint32_t failCounter = 0;
-  
- while(1){
-    
-	// The gateway handles all IP traffic (marked as EXTERNAL_DATA_TYPE) and passes it to the associated network interface
-	// RF24Network user payloads are loaded into the user cache
-	gw.interrupts(0); // Disable interrupts while accessing the radio
-    
-    if( network.available() ){
-	  RF24NetworkHeader header;
-		size_t size = network.peek(header);
-		uint8_t buf[size];
-	    network.read(header,&buf,size);
-	  printf("Received Network Message, type: %d id %d from %d\n",header.type,header.id,mesh.getNodeID(header.from_node));
-	}
+    //Config for use with RF24Mesh as child Node
+    // uint8_t nodeID = 1;
+    // gw.begin(nodeID);
 
-   
-   if(millis()-mesh_timer > 30000 && mesh.getNodeID() > 0){ //Every 30 seconds, test mesh connectivity
-     mesh_timer = millis();
-     if( ! mesh.checkConnection() ){
-       //refresh the network address 
-       mesh.renewAddress();
-     }
-   }    
+    //Config for use without RF24Mesh
+    // uint16_t RF24NetworkAddress = 0;
+    // gw.begin(RF24NetworkAddress);
 
-   //This section checks for failures detected by RF24 & RF24Network as well as
-   //checking for deviations from the default configuration (1MBPS data rate)
-   //The mesh is restarted on failure and failure count logged to failLog.txt
-   //This makes the radios hot-swappable, disconnect & reconnect as desired, it should come up automatically
-   if(radio.failureDetected > 0 || radio.getDataRate() != RF24_1MBPS){
-     radio.failureDetected = 0;
-     std::ofstream myFile;
-     myFile.open ("failLog.txt");
-     if (myFile.is_open()){
-       myFile << ++failCounter << "\n";
-       myFile.close();
-     }
-     delay(500);
-     mesh.begin();
-   }
-   
-   gw.interrupts(); // Re-enable interrupts when done accessing the radio
-   
-      
-   //When using interrupts, gw.poll(); needs to be called to handle incoming data from the network interface.
-   //The function will perform a delayed wait of max 3ms unless otherwise specified.
-   gw.poll(3);
+    //Set this to your chosen IP/Subnet
+    char ip[] = "10.10.2.2";
+    char subnet[] = "255.255.255.0";
 
-  }
-  return 0;
+    gw.setIP(ip, subnet);
+    radio.maskIRQ(1, 1, 0);
+    attachInterrupt(23, INT_EDGE_FALLING, intHandler);
+
+    uint32_t failCounter = 0;
+
+    while (1) {
+
+        // The gateway handles all IP traffic (marked as EXTERNAL_DATA_TYPE) and passes it to the associated network interface
+        // RF24Network user payloads are loaded into the user cache
+        gw.interrupts(0); // Disable interrupts while accessing the radio
+
+        if (network.available()) {
+            RF24NetworkHeader header;
+            size_t size = network.peek(header);
+            uint8_t buf[size];
+            network.read(header, &buf, size);
+            printf("Received Network Message, type: %d id %d from %d\n", header.type, header.id, mesh.getNodeID(header.from_node));
+        }
+
+        if (millis() - mesh_timer > 30000 && mesh.getNodeID() > 0) { //Every 30 seconds, test mesh connectivity
+            mesh_timer = millis();
+            if (!mesh.checkConnection()) {
+                //refresh the network address
+                mesh.renewAddress();
+            }
+        }
+
+        //This section checks for failures detected by RF24 & RF24Network as well as
+        //checking for deviations from the default configuration (1MBPS data rate)
+        //The mesh is restarted on failure and failure count logged to failLog.txt
+        //This makes the radios hot-swappable, disconnect & reconnect as desired, it should come up automatically
+        if (radio.failureDetected > 0 || radio.getDataRate() != RF24_1MBPS) {
+            radio.failureDetected = 0;
+            std::ofstream myFile;
+            myFile.open("failLog.txt");
+            if (myFile.is_open()) {
+                myFile << ++failCounter << "\n";
+                myFile.close();
+            }
+            delay(500);
+            mesh.begin();
+        }
+
+        gw.interrupts(); // Re-enable interrupts when done accessing the radio
+
+        //When using interrupts, gw.poll(); needs to be called to handle incoming data from the network interface.
+        //The function will perform a delayed wait of max 3ms unless otherwise specified.
+        gw.poll(3);
+    }
+    return 0;
 }

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -646,14 +646,16 @@ void drawRF24Pad()
     wprintw(rf24Pad, "nodeID: %d\n", mesh.getNodeID());
     wprintw(rf24Pad, "En Mesh: %s\n", gw.meshEnabled() ? "True" : "False");
     int dr = radio.getDataRate();
-    wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS"
-                : dr == 2                                           ? "250KBPS"
-                                                                    : "ERROR");
     int pa = radio.getPALevel();
+    // clang-format off
+    wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS"
+                                                          : dr == 2	? "250KBPS"
+                                                                    : "ERROR");
     wprintw(rf24Pad, "PA Level: %s\n", pa == 0 ? "MIN" : pa == 1 ? "LOW"
-                : pa == 2                                        ? "HIGH"
-                : pa == 3                                        ? "MAX"
+                                                       : pa == 2 ? "HIGH"
+                                                       : pa == 3 ? "MAX"
                                                                  : "ERROR");
+    // clang-format on
     wprintw(rf24Pad, "IF Type: %s\n", gw.config_TUN == 1 ? "TUN" : "TAP");
     wprintw(rf24Pad, "IF Drops: %u\n", gw.ifDropped());
 #if defined(ENABLE_NETWORK_STATS)

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -51,13 +51,13 @@ RF24Gateway gw(radio, network, mesh);
 
 /******************************************************************/
 
-WINDOW *win;
-WINDOW *meshPad;
-WINDOW *connPad;
-WINDOW *devPad;
-WINDOW *rf24Pad;
-WINDOW *cfgPad;
-WINDOW *renewPad;
+WINDOW* win;
+WINDOW* meshPad;
+WINDOW* connPad;
+WINDOW* devPad;
+WINDOW* rf24Pad;
+WINDOW* cfgPad;
+WINDOW* renewPad;
 
 void drawMain(void);
 void drawHelp(void);
@@ -183,7 +183,7 @@ int main()
 
                     time_t mTime;
                     time(&mTime);
-                    struct tm *tm = localtime(&mTime);
+                    struct tm* tm = localtime(&mTime);
 
                     myTime.hr = tm->tm_hour;
                     myTime.min = tm->tm_min;
@@ -229,85 +229,86 @@ int main()
             //cout << myChar << endl;
             switch (myChar)
             {
-            // a: En/Disable display of active connections
-            case 'a':                
-                if(topo){
+                // a: En/Disable display of active connections
+                case 'a':
+                    if (topo) {
+                        showConnPad = true;
+                    }
+                    else {
+                        showConnPad = !showConnPad;
+                    }
+                    topo = false;
+                    if (!showConnPad)
+                    {
+                        wclear(connPad);
+                        prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
+                        drawMain();
+                    }
+                    break;
+                // w: Increase frame-rate of curses display
+                case 'w':
+                    if (updateRate > 100)
+                    {
+                        updateRate -= 100;
+                    }
+                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
+                    refresh();
+                    break;
+                // s: Decrease frame-rate of curses display
+                case 's':
+                    updateRate += 100;
+                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
+                    refresh();
+                    break;
+                // c: Display IP configuration menu
+                case 'c':
+                    drawCfg(1);
+                    break;
+                // h: Display help menu
+                case 'h':
+                    drawHelp();
+                    break;
+                case 'x':
+                    clear();
+                    endwin();
+                    return 0;
+                    break;
+                case 'A':
+                    if (padSelection == 0)
+                    {
+                        meshScroll++;
+                    }
+                    else if (padSelection == 1)
+                    {
+                        connScroll++;
+                    }
+                    break;
+                case 'B':
+                    if (padSelection == 0)
+                    {
+                        meshScroll--;
+                    }
+                    else if (padSelection == 1)
+                    {
+                        connScroll--;
+                    }
+                    break;
+                case 'C':
+                    padSelection++;
+                    padSelection = std::min(padSelection, 1);
+                    break; //right
+                case 'D':
+                    padSelection--;
+                    padSelection = std::max(padSelection, 0);
+                    break; //left
+                    meshScroll = std::max(meshScroll, 0);
+                    connScroll = std::max(connScroll, 0);
+                    meshInfoTimer = 0;
+                case 't':
+                    //drawTopology();
+                    topo = true;
                     showConnPad = true;
-                }else{
-                  showConnPad = !showConnPad;
-                }
-                topo = false;
-                if (!showConnPad)
-                {
-                    wclear(connPad);
-                    prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
-                    drawMain();
-                }
-                break;
-            // w: Increase frame-rate of curses display
-            case 'w':
-                if (updateRate > 100)
-                {
-                    updateRate -= 100;
-                }
-                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
-                refresh();
-                break;
-            // s: Decrease frame-rate of curses display
-            case 's':
-                updateRate += 100;
-                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
-                refresh();
-                break;
-            // c: Display IP configuration menu
-            case 'c':
-                drawCfg(1);
-                break;
-            // h: Display help menu
-            case 'h':
-                drawHelp();
-                break;
-            case 'x':
-                clear();
-                endwin();
-                return 0;
-                break;
-            case 'A':
-                if (padSelection == 0)
-                {
-                    meshScroll++;
-                }
-                else if (padSelection == 1)
-                {
-                    connScroll++;
-                }
-                break;
-            case 'B':
-                if (padSelection == 0)
-                {
-                    meshScroll--;
-                }
-                else if (padSelection == 1)
-                {
-                    connScroll--;
-                }
-                break;
-            case 'C':
-                padSelection++;
-                padSelection = std::min(padSelection, 1);
-                break; //right
-            case 'D':
-                padSelection--;
-                padSelection = std::max(padSelection, 0);
-                break; //left
-                meshScroll = std::max(meshScroll, 0);
-                connScroll = std::max(connScroll, 0);
-                meshInfoTimer = 0;
-             case 't':
-                //drawTopology();
-                topo = true;
-                showConnPad = true;
-                break;
+                    break;
             }
         }
 
@@ -343,84 +344,90 @@ int main()
 /******************************************************************/
 /******************Main Drawing Functions**************************/
 
-void drawTopology(){
-   wclear(connPad);
-   wattroff(connPad, COLOR_PAIR(1));
-   mvwhline(win, 15, 1, ACS_HLINE, maxY - 2);
-   mvwprintw(win,15,10,"Mesh Topology");
-   
-   wattron(connPad,COLOR_PAIR(1));
-   int connPadmaxX;
-   connPadmaxX = getmaxx(connPad);
- 
-   for (int i = 01; i < 06; i++){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         wprintw(connPad,"0%o[%d]   |    ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
+void drawTopology()
+{
+    wclear(connPad);
+    wattroff(connPad, COLOR_PAIR(1));
+    mvwhline(win, 15, 1, ACS_HLINE, maxY - 2);
+    mvwprintw(win, 15, 10, "Mesh Topology");
 
-     }
-   }
-  wprintw(connPad,"\n");
-  wattron(connPad,COLOR_PAIR(3)); 
-  uint16_t g = 051; 
-  for(int h = 011; h <= 015; h++){
-   
-   for (int i = h; i <= g; i+=010){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         int y=0; int x=0;
-         getyx(connPad,y,x);
-         if(x > connPadmaxX-77){ wprintw(connPad,"\n"); }
-         wprintw(connPad,"0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
-     }
-   }
-   g++;
-   wprintw(connPad, "| ");
-  }
-  wprintw(connPad,"\n");
-  wattron(connPad,COLOR_PAIR(4)); 
-  g = 0411; 
-  for(int h = 0111; h <= 0145; h++){
-   
-   for (int i = h; i <= g; i+=0100){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         int y=0; int x=0;
-         getyx(connPad, y, x);
-         if(x > connPadmaxX-77){ wprintw(connPad,"\n"); }         
-         wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
-     }
-   }
-   g++;
+    wattron(connPad, COLOR_PAIR(1));
+    int connPadmaxX;
+    connPadmaxX = getmaxx(connPad);
 
-  }
-  wprintw(connPad,"\n");
-  wattron(connPad,COLOR_PAIR(2));
-  g = 04111; 
-  
-  for(int h = 01111; h <= 01445; h++){
-   
-   for (int i = h; i <= g; i+=01000){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         int y=0; int x=0;
-         getyx(connPad,y,x);
-         if(x > connPadmaxX-77){ wprintw(connPad,"\n"); }         
-         wprintw(connPad,"0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
-     }
-   }
-   g++;
+    for (int i = 01; i < 06; i++) {
 
-  }
+        for (int j = 0; j < mesh.addrListTop; j++) {
+            if (mesh.addrList[j].address == i) {
+                wprintw(connPad, "0%o[%d]   |    ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+            }
+        }
+    }
+    wprintw(connPad, "\n");
+    wattron(connPad, COLOR_PAIR(3));
+    uint16_t g = 051;
+    for (int h = 011; h <= 015; h++) {
 
+        for (int i = h; i <= g; i += 010) {
+
+            for (int j = 0; j < mesh.addrListTop; j++) {
+                if (mesh.addrList[j].address == i) {
+                    int y = 0;
+                    int x = 0;
+                    getyx(connPad, y, x);
+                    if (x > connPadmaxX - 77) {
+                        wprintw(connPad, "\n");
+                    }
+                    wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+                }
+            }
+        }
+        g++;
+        wprintw(connPad, "| ");
+    }
+    wprintw(connPad, "\n");
+    wattron(connPad, COLOR_PAIR(4));
+    g = 0411;
+    for (int h = 0111; h <= 0145; h++) {
+
+        for (int i = h; i <= g; i += 0100) {
+
+            for (int j = 0; j < mesh.addrListTop; j++) {
+                if (mesh.addrList[j].address == i) {
+                    int y = 0;
+                    int x = 0;
+                    getyx(connPad, y, x);
+                    if (x > connPadmaxX - 77) {
+                        wprintw(connPad, "\n");
+                    }
+                    wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+                }
+            }
+        }
+        g++;
+    }
+    wprintw(connPad, "\n");
+    wattron(connPad, COLOR_PAIR(2));
+    g = 04111;
+
+    for (int h = 01111; h <= 01445; h++) {
+
+        for (int i = h; i <= g; i += 01000) {
+
+            for (int j = 0; j < mesh.addrListTop; j++) {
+                if (mesh.addrList[j].address == i) {
+                    int y = 0;
+                    int x = 0;
+                    getyx(connPad, y, x);
+                    if (x > connPadmaxX - 77) {
+                        wprintw(connPad, "\n");
+                    }
+                    wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+                }
+            }
+        }
+        g++;
+    }
 }
 
 void drawMain()
@@ -640,12 +647,12 @@ void drawRF24Pad()
     wprintw(rf24Pad, "En Mesh: %s\n", gw.meshEnabled() ? "True" : "False");
     int dr = radio.getDataRate();
     wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS"
-                                                        : dr == 2	? "250KBPS"
+                : dr == 2                                           ? "250KBPS"
                                                                     : "ERROR");
     int pa = radio.getPALevel();
     wprintw(rf24Pad, "PA Level: %s\n", pa == 0 ? "MIN" : pa == 1 ? "LOW"
-                                                     : pa == 2	 ? "HIGH"
-                                                     : pa == 3	 ? "MAX"
+                : pa == 2                                        ? "HIGH"
+                : pa == 3                                        ? "MAX"
                                                                  : "ERROR");
     wprintw(rf24Pad, "IF Type: %s\n", gw.config_TUN == 1 ? "TUN" : "TAP");
     wprintw(rf24Pad, "IF Drops: %u\n", gw.ifDropped());
@@ -676,9 +683,9 @@ void drawRF24Pad()
 
 void drawConnPad()
 {
-    if( topo ){
-      drawTopology();
-      return;
+    if (topo) {
+        drawTopology();
+        return;
     }
     wattroff(connPad, COLOR_PAIR(2));
     int ctr = 0;
@@ -713,8 +720,7 @@ void drawConnPad()
 
     inFile.close();
     mvwhline(win, 15, 1, ACS_HLINE, maxY - 2);
-    mvwprintw(win,15,10,"Active IP Connections:");
-
+    mvwprintw(win, 15, 10, "Active IP Connections:");
 }
 
 /******************************************************************/

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -684,13 +684,15 @@ void drawRF24Pad()
     int dr = radio.getDataRate();
     int pa = radio.getPALevel();
     radio.maskIRQ(1, 1, 0);
+    // clang-format off
     wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS"
-                : dr == 2                                           ? "250KBPS"
+                                                          : dr == 2 ? "250KBPS"
                                                                     : "ERROR");
     wprintw(rf24Pad, "PA Level: %s\n", pa == 0 ? "MIN" : pa == 1 ? "LOW"
-                : pa == 2                                        ? "HIGH"
-                : pa == 3                                        ? "MAX"
+                                                       : pa == 2 ? "HIGH"
+                                                       : pa == 3 ? "MAX"
                                                                  : "ERROR");
+    // clang-format on
     wprintw(rf24Pad, "IF Type: %s\n", gw.config_TUN == 1 ? "TUN" : "TAP");
     wprintw(rf24Pad, "IF Drops: %u\n", gw.ifDropped());
 #if defined(ENABLE_NETWORK_STATS)

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -53,13 +53,13 @@ uint8_t nodeID = 0;
 int interruptPin = 24;
 /******************************************************************/
 
-WINDOW *win;
-WINDOW *meshPad;
-WINDOW *connPad;
-WINDOW *devPad;
-WINDOW *rf24Pad;
-WINDOW *cfgPad;
-WINDOW *renewPad;
+WINDOW* win;
+WINDOW* meshPad;
+WINDOW* connPad;
+WINDOW* devPad;
+WINDOW* rf24Pad;
+WINDOW* cfgPad;
+WINDOW* renewPad;
 
 void drawMain(void);
 void drawHelp(void);
@@ -201,7 +201,7 @@ int main()
 
                     time_t mTime;
                     time(&mTime);
-                    struct tm *tm = localtime(&mTime);
+                    struct tm* tm = localtime(&mTime);
 
                     myTime.hr = tm->tm_hour;
                     myTime.min = tm->tm_min;
@@ -258,89 +258,90 @@ int main()
             //cout << myChar << endl;
             switch (myChar)
             {
-            // a: En/Disable display of active connections
-            case 'a':
-                if(topo){
+                // a: En/Disable display of active connections
+                case 'a':
+                    if (topo) {
+                        showConnPad = true;
+                    }
+                    else {
+                        showConnPad = !showConnPad;
+                    }
+                    topo = false;
+                    if (!showConnPad)
+                    {
+                        wclear(connPad);
+                        prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
+                        drawMain();
+                    }
+                    break;
+                // w: Increase frame-rate of curses display
+                case 'w':
+                    if (updateRate > 100)
+                    {
+                        updateRate -= 100;
+                    }
+                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
+                    refresh();
+                    break;
+                // s: Decrease frame-rate of curses display
+                case 's':
+                    updateRate += 100;
+                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
+                    refresh();
+                    break;
+                // c: Display IP configuration menu
+                case 'c':
+                    drawCfg(1);
+                    break;
+                // h: Display help menu
+                case 'h':
+                    drawHelp();
+                    break;
+                case 'x':
+                    clear();
+                    endwin();
+                    return 0;
+                    break;
+                case KEY_UP:
+                    if (padSelection == 0)
+                    {
+                        meshScroll++;
+                    }
+                    else if (padSelection == 1)
+                    {
+                        connScroll++;
+                    }
+                    break;
+                case KEY_DOWN:
+                    if (padSelection == 0)
+                    {
+                        meshScroll--;
+                    }
+                    else if (padSelection == 1)
+                    {
+                        connScroll--;
+                    }
+                    break;
+                case KEY_RIGHT:
+                    padSelection++;
+                    padSelection = std::min(padSelection, 1);
+                    break; //right
+                case KEY_LEFT:
+                    padSelection--;
+                    padSelection = std::max(padSelection, 0);
+                    break; //left
+                case 'Q':
+                    clear();
+                    endwin();
+                    return 0;
+                    break;
+                    meshScroll = std::max(meshScroll, 0);
+                    connScroll = std::max(connScroll, 0);
+                    meshInfoTimer = 0;
+                case 't':
+                    topo = true;
                     showConnPad = true;
-                }else{
-                  showConnPad = !showConnPad;
-                }
-                topo = false;
-                if (!showConnPad)
-                {
-                    wclear(connPad);
-                    prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
-                    drawMain();
-                }
-                break;
-            // w: Increase frame-rate of curses display
-            case 'w':
-                if (updateRate > 100)
-                {
-                    updateRate -= 100;
-                }
-                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
-                refresh();
-                break;
-            // s: Decrease frame-rate of curses display
-            case 's':
-                updateRate += 100;
-                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
-                refresh();
-                break;
-            // c: Display IP configuration menu
-            case 'c':
-                drawCfg(1);
-                break;
-            // h: Display help menu
-            case 'h':
-                drawHelp();
-                break;
-            case 'x':
-                clear();
-                endwin();
-                return 0;
-                break;
-            case KEY_UP:
-                if (padSelection == 0)
-                {
-                    meshScroll++;
-                }
-                else if (padSelection == 1)
-                {
-                    connScroll++;
-                }
-                break;
-            case KEY_DOWN:
-                if (padSelection == 0)
-                {
-                    meshScroll--;
-                }
-                else if (padSelection == 1)
-                {
-                    connScroll--;
-                }
-                break;
-            case KEY_RIGHT:
-                padSelection++;
-                padSelection = std::min(padSelection, 1);
-                break; //right
-            case KEY_LEFT:
-                padSelection--;
-                padSelection = std::max(padSelection, 0);
-                break; //left
-            case 'Q':
-                clear();
-                endwin();
-                return 0;
-                break;
-                meshScroll = std::max(meshScroll, 0);
-                connScroll = std::max(connScroll, 0);
-                meshInfoTimer = 0;
-             case 't':
-                topo = true;
-                showConnPad = true;
-                break;
+                    break;
             }
         }
 
@@ -378,85 +379,90 @@ int main()
 /******************************************************************/
 /******************Main Drawing Functions**************************/
 
+void drawTopology()
+{
+    wclear(connPad);
+    wattroff(connPad, COLOR_PAIR(1));
+    mvwhline(win, 15, 1, ACS_HLINE, maxY - 2);
+    mvwprintw(win, 15, 10, "Mesh Topology");
 
-void drawTopology(){
-   wclear(connPad);
-   wattroff(connPad, COLOR_PAIR(1));
-   mvwhline(win, 15, 1, ACS_HLINE, maxY - 2);
-   mvwprintw(win,15,10,"Mesh Topology");
-   
-   wattron(connPad,COLOR_PAIR(1));
-   int connPadmaxX;
-   connPadmaxX = getmaxx(connPad);
- 
-   for (int i = 01; i < 06; i++){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         wprintw(connPad,"0%o[%d]   |    ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
+    wattron(connPad, COLOR_PAIR(1));
+    int connPadmaxX;
+    connPadmaxX = getmaxx(connPad);
 
-     }
-   }
-  wprintw(connPad,"\n");
-  wattron(connPad,COLOR_PAIR(3)); 
-  uint16_t g = 051; 
-  for(int h = 011; h <= 015; h++){
-   
-   for (int i = h; i <= g; i+=010){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         int y=0; int x=0;
-         getyx(connPad,y,x);
-         if(x > connPadmaxX-77){ wprintw(connPad,"\n"); }
-         wprintw(connPad,"0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
-     }
-   }
-   g++;
-   wprintw(connPad, "| ");
-  }
-  wprintw(connPad,"\n");
-  wattron(connPad,COLOR_PAIR(4)); 
-  g = 0411; 
-  for(int h = 0111; h <= 0145; h++){
-   
-   for (int i = h; i <= g; i+=0100){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         int y=0; int x=0;
-         getyx(connPad, y, x);
-         if(x > connPadmaxX-77){ wprintw(connPad,"\n"); }         
-         wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
-     }
-   }
-   g++;
+    for (int i = 01; i < 06; i++) {
 
-  }
-  wprintw(connPad,"\n");
-  wattron(connPad,COLOR_PAIR(2));
-  g = 04111; 
-  
-  for(int h = 01111; h <= 01445; h++){
-   
-   for (int i = h; i <= g; i+=01000){
-       
-     for (int j = 0; j < mesh.addrListTop; j++){
-       if(mesh.addrList[j].address == i){
-         int y=0; int x=0;
-         getyx(connPad,y,x);
-         if(x > connPadmaxX-77){ wprintw(connPad,"\n"); }         
-         wprintw(connPad,"0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
-       }
-     }
-   }
-   g++;
+        for (int j = 0; j < mesh.addrListTop; j++) {
+            if (mesh.addrList[j].address == i) {
+                wprintw(connPad, "0%o[%d]   |    ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+            }
+        }
+    }
+    wprintw(connPad, "\n");
+    wattron(connPad, COLOR_PAIR(3));
+    uint16_t g = 051;
+    for (int h = 011; h <= 015; h++) {
 
-  }
+        for (int i = h; i <= g; i += 010) {
 
+            for (int j = 0; j < mesh.addrListTop; j++) {
+                if (mesh.addrList[j].address == i) {
+                    int y = 0;
+                    int x = 0;
+                    getyx(connPad, y, x);
+                    if (x > connPadmaxX - 77) {
+                        wprintw(connPad, "\n");
+                    }
+                    wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+                }
+            }
+        }
+        g++;
+        wprintw(connPad, "| ");
+    }
+    wprintw(connPad, "\n");
+    wattron(connPad, COLOR_PAIR(4));
+    g = 0411;
+    for (int h = 0111; h <= 0145; h++) {
+
+        for (int i = h; i <= g; i += 0100) {
+
+            for (int j = 0; j < mesh.addrListTop; j++) {
+                if (mesh.addrList[j].address == i) {
+                    int y = 0;
+                    int x = 0;
+                    getyx(connPad, y, x);
+                    if (x > connPadmaxX - 77) {
+                        wprintw(connPad, "\n");
+                    }
+                    wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+                }
+            }
+        }
+        g++;
+    }
+    wprintw(connPad, "\n");
+    wattron(connPad, COLOR_PAIR(2));
+    g = 04111;
+
+    for (int h = 01111; h <= 01445; h++) {
+
+        for (int i = h; i <= g; i += 01000) {
+
+            for (int j = 0; j < mesh.addrListTop; j++) {
+                if (mesh.addrList[j].address == i) {
+                    int y = 0;
+                    int x = 0;
+                    getyx(connPad, y, x);
+                    if (x > connPadmaxX - 77) {
+                        wprintw(connPad, "\n");
+                    }
+                    wprintw(connPad, "0%o[%d] ", mesh.addrList[j].address, mesh.addrList[j].nodeID);
+                }
+            }
+        }
+        g++;
+    }
 }
 
 void drawMain()
@@ -678,8 +684,13 @@ void drawRF24Pad()
     int dr = radio.getDataRate();
     int pa = radio.getPALevel();
     radio.maskIRQ(1, 1, 0);
-    wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS" : dr == 2   ? "250KBPS" : "ERROR");
-    wprintw(rf24Pad, "PA Level: %s\n", pa == 0 ? "MIN" : pa == 1 ? "LOW" : pa == 2   ? "HIGH" : pa == 3   ? "MAX" : "ERROR");
+    wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS"
+                : dr == 2                                           ? "250KBPS"
+                                                                    : "ERROR");
+    wprintw(rf24Pad, "PA Level: %s\n", pa == 0 ? "MIN" : pa == 1 ? "LOW"
+                : pa == 2                                        ? "HIGH"
+                : pa == 3                                        ? "MAX"
+                                                                 : "ERROR");
     wprintw(rf24Pad, "IF Type: %s\n", gw.config_TUN == 1 ? "TUN" : "TAP");
     wprintw(rf24Pad, "IF Drops: %u\n", gw.ifDropped());
 #if defined(ENABLE_NETWORK_STATS)
@@ -715,9 +726,9 @@ void drawRF24Pad()
 
 void drawConnPad()
 {
-    if( topo ){
-      drawTopology();
-      return;
+    if (topo) {
+        drawTopology();
+        return;
     }
     wattroff(connPad, COLOR_PAIR(2));
     int ctr = 0;
@@ -752,7 +763,7 @@ void drawConnPad()
 
     inFile.close();
     mvwhline(win, 15, 1, ACS_HLINE, maxY - 2);
-    mvwprintw(win,15,10,"Active IP Connections:");
+    mvwprintw(win, 15, 10, "Active IP Connections:");
 }
 
 /******************************************************************/


### PR DESCRIPTION
- add clang-format config file
- updated CI workflow to check formatting (for all C++ sources including examples)
- ran clang-format on all C++ sources


## Notes
There are some very long inline conditional expressions in the ncurses examples that seem to have gotten a slightly weird formatting. I can tell clang-format to ignore these lines if these changes are undesirable. I think its confusing `:` for an assignment operator.
```diff
     wprintw(rf24Pad, "Data-Rate: %s\n", dr == 0 ? "1MBPS" : dr == 1 ? "2MBPS"
-                                                        : dr == 2	? "250KBPS"
+                : dr == 2                                           ? "250KBPS"
                                                                     : "ERROR");
     int pa = radio.getPALevel();
     wprintw(rf24Pad, "PA Level: %s\n", pa == 0 ? "MIN" : pa == 1 ? "LOW"
-                                                     : pa == 2	 ? "HIGH"
-                                                     : pa == 3	 ? "MAX"
+                : pa == 2                                        ? "HIGH"
+                : pa == 3                                        ? "MAX"
                                                                  : "ERROR");
```