### PR TITLE
Comment out setStaticAddress in example

### DIFF
--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -94,7 +94,7 @@ int main()
 {
 
     gw.begin();
-    mesh.setStaticAddress(8, 1);
+    //mesh.setStaticAddress(8, 1);
 
     //uint8_t nodeID = 22;
     //gw.begin(nodeID,3,RF24_2MBPS);


### PR DESCRIPTION
This line can be a source of confusion if left enabled as it adds a static node on the master node, but can cause a segfault if called on non-master node