### PR TITLE
Warnings if unable to config interface

### DIFF
--- a/RF24Gateway.cpp
+++ b/RF24Gateway.cpp
@@ -211,8 +211,8 @@ int ESBGateway<mesh_t, network_t, radio_t>::allocateTunDevice(char* dev, int fla
         std::cerr << "RF24Gw: Error: enabling TUNSETIFF" << std::endl;
         uint32_t UID = getuid();
         if (UID) {
-            std::cout << "Not running as root, preconfigure the interface as follows, where 'pi' is your username" << std::endl;
-            std::cout << "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue" << std::endl;
+            std::cout << "Not running as root, preconfigure the interface as follows" << std::endl;
+            std::cout << "sudo ip tuntap add dev tun_nrf24 mode tun user " << getlogin() << " multi_queue" << std::endl;
             std::cout << "sudo ifconfig tun_nrf24 10.10.2.2/24" << std::endl;
         }
         return -1;

--- a/RF24Gateway.cpp
+++ b/RF24Gateway.cpp
@@ -209,7 +209,12 @@ int ESBGateway<mesh_t, network_t, radio_t>::allocateTunDevice(char* dev, int fla
         // close(fd);
         //#if (RF24GATEWAY_DEBUG_LEVEL >= 1)
         std::cerr << "RF24Gw: Error: enabling TUNSETIFF" << std::endl;
-        std::cerr << "RF24Gw: If changing from TAP/TUN, run 'sudo ip link delete tun_nrf24' to remove the interface" << std::endl;
+        uint32_t UID = getuid();
+        if (UID) {
+            std::cout << "Not running as root, preconfigure the interface as follows, where 'pi' is your username" << std::endl;
+            std::cout << "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue" << std::endl;
+            std::cout << "sudo ifconfig tun_nrf24 10.10.2.2/24" << std::endl;
+        }
         return -1;
         //#endif
     }

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -551,8 +551,8 @@ void drawCfg(bool isConf)
             mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
             uint32_t UID = getuid();
             if (UID) {
-                mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
-                mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
+                mvwprintw(win, 9, 1, "Not running as root, configure as follows:\n");
+                mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user %s multi_queue\n", getlogin());
                 mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
             }
             refresh();

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -547,18 +547,17 @@ void drawCfg(bool isConf)
 
     if (strlen(ip) >= 6 && strlen(mask) >= 7)
     {
-        if(gw.setIP(ip, mask) < 0){
-          mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
-          uint32_t UID = getuid();
-          if (UID) {
-            mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
-            mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
-            mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
-          }
-          refresh();
-          sleep(10);
+        if (gw.setIP(ip, mask) < 0) {
+            mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
+            uint32_t UID = getuid();
+            if (UID) {
+                mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
+                mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
+                mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
+            }
+            refresh();
+            sleep(10);
         }
-            
     }
     else
     {

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -531,7 +531,8 @@ void drawCfg(bool isConf)
 
     sleep(1);
     wattron(win, COLOR_PAIR(1));
-    mvwprintw(win, 5, 1, isConf ? "IP Configuration\n" : "**Interface Not Configured:**\n");
+    mvwprintw(win, 4, 1, isConf ? "IP Configuration\n" : "**Interface Not Configured:**\n");
+    mvwprintw(win, 5, 1, "IP 10.10.2.2 and Subnet Mask 255.255.255.0 is default\n");
     wattroff(win, COLOR_PAIR(1));
     mvwprintw(win, 6, 1, "Enter IP Address: \n");
     refresh();
@@ -546,7 +547,18 @@ void drawCfg(bool isConf)
 
     if (strlen(ip) >= 6 && strlen(mask) >= 7)
     {
-        gw.setIP(ip, mask);
+        if(gw.setIP(ip, mask) < 0){
+          mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
+          uint32_t UID = getuid();
+          if (UID) {
+            mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
+            mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
+            mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
+          }
+          refresh();
+          sleep(10);
+        }
+            
     }
     else
     {

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -579,8 +579,8 @@ void drawCfg(bool isConf)
             mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
             uint32_t UID = getuid();
             if (UID) {
-                mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
-                mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
+                mvwprintw(win, 9, 1, "Not running as root, configure as follows:\n");
+                mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user %s multi_queue\n", getlogin());
                 mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
             }
             refresh();

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -559,7 +559,8 @@ void drawCfg(bool isConf)
 
     sleep(1);
     wattron(win, COLOR_PAIR(1));
-    mvwprintw(win, 5, 1, isConf ? "IP Configuration\n" : "**Interface Not Configured:**\n");
+    mvwprintw(win, 4, 1, isConf ? "IP Configuration\n" : "**Interface Not Configured:**\n");
+    mvwprintw(win, 5, 1, "IP 10.10.2.2 and Subnet Mask 255.255.255.0 is default\n");
     wattroff(win, COLOR_PAIR(1));
     mvwprintw(win, 6, 1, "Enter IP Address: \n");
     refresh();
@@ -574,7 +575,18 @@ void drawCfg(bool isConf)
 
     if (strlen(ip) >= 6 && strlen(mask) >= 7)
     {
-        gw.setIP(ip, mask);
+        if(gw.setIP(ip, mask) < 0){
+          mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
+          uint32_t UID = getuid();
+          if (UID) {
+            mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
+            mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
+            mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
+          }
+          refresh();
+          sleep(10);
+        }
+            
     }
     else
     {

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -575,18 +575,17 @@ void drawCfg(bool isConf)
 
     if (strlen(ip) >= 6 && strlen(mask) >= 7)
     {
-        if(gw.setIP(ip, mask) < 0){
-          mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
-          uint32_t UID = getuid();
-          if (UID) {
-            mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
-            mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
-            mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
-          }
-          refresh();
-          sleep(10);
+        if (gw.setIP(ip, mask) < 0) {
+            mvwprintw(win, 8, 1, "Unable to set IP/Subnet \n");
+            uint32_t UID = getuid();
+            if (UID) {
+                mvwprintw(win, 9, 1, "Not running as root, configure as follows, where 'pi' is your username:\n");
+                mvwprintw(win, 10, 1, "sudo ip tuntap add dev tun_nrf24 mode tun user pi multi_queue\n");
+                mvwprintw(win, 11, 1, "sudo ifconfig tun_nrf24 10.10.2.2/24\n");
+            }
+            refresh();
+            sleep(10);
         }
-            
     }
     else
     {


### PR DESCRIPTION
- Add some warnings with detailed descriptions of the problem and what to do if configuration of the network interface fails (usually because not running as root)