### PR TITLE
Improvements for examples

### DIFF
--- a/examples/RF24GatewayNode.cpp
+++ b/examples/RF24GatewayNode.cpp
@@ -31,6 +31,7 @@ int main(int argc, char** argv)
 
     gw.setIP(ip, subnet);
     uint32_t failCounter = 0;
+    uint32_t failTimer = 0;
 
     while (1)
     {
@@ -64,18 +65,21 @@ int main(int argc, char** argv)
         //checking for deviations from the default configuration (1MBPS data rate)
         //The mesh is restarted on failure and failure count logged to failLog.txt
         //This makes the radios hot-swappable, disconnect & reconnect as desired, it should come up automatically
-        if (radio.failureDetected > 0 || radio.getDataRate() != RF24_1MBPS)
-        {
-            radio.failureDetected = 0;
-            std::ofstream myFile;
-            myFile.open("failLog.txt");
-            if (myFile.is_open())
+        if (millis() - failTimer > 1000) {
+            failTimer = millis();
+            if (radio.failureDetected > 0 || radio.getDataRate() != RF24_1MBPS)
             {
-                myFile << ++failCounter << "\n";
-                myFile.close();
+                radio.failureDetected = 0;
+                std::ofstream myFile;
+                myFile.open("failLog.txt");
+                if (myFile.is_open())
+                {
+                    myFile << ++failCounter << "\n";
+                    myFile.close();
+                }
+                delay(500);
+                mesh.begin();
             }
-            delay(500);
-            mesh.begin();
         }
     }
     return 0;

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -718,7 +718,7 @@ bool handleKeyPad()
                 }
                 else if (padSelection == 1)
                 {
-                    connScroll++;
+                    connScroll = rf24_max(connScroll++, 0);
                 }
                 break;
             case 'B':

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -739,11 +739,7 @@ bool handleKeyPad()
                 padSelection--;
                 padSelection = std::max(padSelection, 0);
                 break; //left
-                meshScroll = std::max(meshScroll, 0);
-                connScroll = std::max(connScroll, 0);
-                meshInfoTimer = 0;
             case 't':
-                //drawTopology();
                 topo = true;
                 showConnPad = !showConnPad;
                 clear();

--- a/examples/ncurses/RF24Gateway_ncurses.cpp
+++ b/examples/ncurses/RF24Gateway_ncurses.cpp
@@ -132,7 +132,7 @@ int main()
     timeout(0);
 
     drawMain();
-    if(!mesh.getNodeID()){
+    if (!mesh.getNodeID()) {
         showConnPad = true;
     }
     /******************************************************************/
@@ -220,7 +220,7 @@ int main()
             }
         } //MeshInfo Timer
 
-        if(!handleKeyPad()){
+        if (!handleKeyPad()) {
             return 0;
         }
 
@@ -654,102 +654,103 @@ void drawConnPad()
 
 /******************************************************************/
 
-        /** Handle keyboard input **/
-        /*******************************/
+/** Handle keyboard input **/
+/*******************************/
 
-bool handleKeyPad(){
-    
-        int myChar = getch();
+bool handleKeyPad()
+{
 
-        if (myChar > -1)
+    int myChar = getch();
+
+    if (myChar > -1)
+    {
+        //cout << myChar << endl;
+        switch (myChar)
         {
-            //cout << myChar << endl;
-            switch (myChar)
-            {
-                // a: En/Disable display of active connections
-                case 'a':
-                    if (topo) {
-                        showConnPad = true;
-                    }
-                    else {
-                        showConnPad = !showConnPad;
-                    }
-                    topo = false;
-                    if (!showConnPad)
-                    {
-                        werase(connPad);
-                        prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
-                        drawMain();
-                    }
-                    break;
-                // w: Increase frame-rate of curses display
-                case 'w':
-                    if (updateRate > 100)
-                    {
-                        updateRate -= 100;
-                    }
-                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
-                    refresh();
-                    break;
-                // s: Decrease frame-rate of curses display
-                case 's':
-                    updateRate += 100;
-                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
-                    refresh();
-                    break;
-                // c: Display IP configuration menu
-                case 'c':
-                    drawCfg(1);
-                    break;
-                // h: Display help menu
-                case 'h':
-                    drawHelp();
-                    break;
-                case 'x':
-                    erase();
-                    endwin();
-                    return 0;
-                    break;
-                case 'A':
-                    if (padSelection == 0)
-                    {
-                        meshScroll++;
-                    }
-                    else if (padSelection == 1)
-                    {
-                        connScroll++;
-                    }
-                    break;
-                case 'B':
-                    if (padSelection == 0)
-                    {
-                        meshScroll--;
-                    }
-                    else if (padSelection == 1)
-                    {
-                        connScroll--;
-                    }
-                    break;
-                case 'C':
-                    padSelection++;
-                    padSelection = std::min(padSelection, 1);
-                    break; //right
-                case 'D':
-                    padSelection--;
-                    padSelection = std::max(padSelection, 0);
-                    break; //left
-                    meshScroll = std::max(meshScroll, 0);
-                    connScroll = std::max(connScroll, 0);
-                    meshInfoTimer = 0;
-                case 't':
-                    //drawTopology();
-                    topo = true;
+            // a: En/Disable display of active connections
+            case 'a':
+                if (topo) {
+                    showConnPad = true;
+                }
+                else {
                     showConnPad = !showConnPad;
-                    clear();
+                }
+                topo = false;
+                if (!showConnPad)
+                {
+                    werase(connPad);
+                    prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
                     drawMain();
-                    meshInfoTimer -= 1000;
-                    break;
-            }
+                }
+                break;
+            // w: Increase frame-rate of curses display
+            case 'w':
+                if (updateRate > 100)
+                {
+                    updateRate -= 100;
+                }
+                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
+                refresh();
+                break;
+            // s: Decrease frame-rate of curses display
+            case 's':
+                updateRate += 100;
+                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
+                refresh();
+                break;
+            // c: Display IP configuration menu
+            case 'c':
+                drawCfg(1);
+                break;
+            // h: Display help menu
+            case 'h':
+                drawHelp();
+                break;
+            case 'x':
+                erase();
+                endwin();
+                return 0;
+                break;
+            case 'A':
+                if (padSelection == 0)
+                {
+                    meshScroll++;
+                }
+                else if (padSelection == 1)
+                {
+                    connScroll++;
+                }
+                break;
+            case 'B':
+                if (padSelection == 0)
+                {
+                    meshScroll--;
+                }
+                else if (padSelection == 1)
+                {
+                    connScroll--;
+                }
+                break;
+            case 'C':
+                padSelection++;
+                padSelection = std::min(padSelection, 1);
+                break; //right
+            case 'D':
+                padSelection--;
+                padSelection = std::max(padSelection, 0);
+                break; //left
+                meshScroll = std::max(meshScroll, 0);
+                connScroll = std::max(connScroll, 0);
+                meshInfoTimer = 0;
+            case 't':
+                //drawTopology();
+                topo = true;
+                showConnPad = !showConnPad;
+                clear();
+                drawMain();
+                meshInfoTimer -= 1000;
+                break;
         }
-        return 1;
+    }
+    return 1;
 }

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -740,7 +740,7 @@ bool handleKeyPad()
                 }
                 else if (padSelection == 1)
                 {
-                    connScroll++;
+                    connScroll = rf24_max(connScroll++, 0);
                 }
                 break;
             case KEY_DOWN:

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -70,6 +70,7 @@ void drawMeshPad(void);
 void drawConnPad(void);
 void drawRF24Pad(void);
 void drawTopology();
+bool handleKeyPad();
 
 int maxX, maxY;
 int padSelection = 0;
@@ -85,7 +86,7 @@ uint32_t mesh_timer = 0;
 size_t networkPacketsRX = 0;
 std::string subIP;
 std::string tunStr("tun_nrf24");
-bool showConnPad;
+bool showConnPad = false;
 bool topo = true;
 
 float bRX;
@@ -145,7 +146,9 @@ int main()
     //gw.setIP(ip,subnet);
 
     drawMain();
-
+    if(!nodeID){
+        showConnPad = true;
+    }
     radio.maskIRQ(1, 1, 0);
     attachInterrupt(interruptPin, INT_EDGE_FALLING, intHandler);
 
@@ -176,41 +179,31 @@ int main()
             mesh_timer = millis();
         }
 
-        if (ok)
-        { //Non-master nodes need an active connection to the mesh in order to handle data
-
-            /** Read RF24Network Payloads (Do nothing with them currently) **/
-            /*******************************/
-            if (network.available())
-            {
-                ++networkPacketsRX;
-                RF24NetworkHeader header;
-                // un-needed variables
-                // size_t size = network.peek(header);
-                // uint8_t buf[size];
-                network.read(header, /*buf*/ 0, /*size*/ 0); // pop the RX payload from network.queue
-
-                // send a timestamp to master
-                struct timeStruct
-                {
-                    uint8_t hr;
-                    uint8_t min;
-                } myTime;
-
-                time_t mTime;
-                time(&mTime);
-                struct tm* tm = localtime(&mTime);
-
-                myTime.hr = tm->tm_hour;
-                myTime.min = tm->tm_min;
-                RF24NetworkHeader hdr(header.from_node, 1);
-                network.write(hdr, &myTime, sizeof(myTime));
-            }
-        }
-        else
+        /** Read RF24Network Payloads (Do nothing with them currently) **/
+        /*******************************/
+        if (network.available())
         {
-            delay(100); //Big delay if connection to RF24Mesh is failing
+            ++networkPacketsRX;
+            RF24NetworkHeader header;
+            network.read(header, /*buf*/ 0, /*size*/ 0); // pop the RX payload from network.queue
+
+            // send a timestamp to master
+            struct timeStruct
+            {
+                uint8_t hr;
+                uint8_t min;
+            } myTime;
+
+            time_t mTime;
+            time(&mTime);
+            struct tm* tm = localtime(&mTime);
+
+            myTime.hr = tm->tm_hour;
+            myTime.min = tm->tm_min;
+            RF24NetworkHeader hdr(header.from_node, 1);
+            network.write(hdr, &myTime, sizeof(myTime));
         }
+  
 
         /**
          * The gateway handles all IP traffic (marked as EXTERNAL_DATA_TYPE) and passes it to the associated network interface
@@ -244,100 +237,10 @@ int main()
             }
         } //MeshInfo Timer
 
-        /** Handle keyboard input **/
-        /*******************************/
-        int myChar = getch();
 
-        if (myChar > -1)
-        {
-            //cout << myChar << endl;
-            switch (myChar)
-            {
-                // a: En/Disable display of active connections
-                case 'a':
-                    if (topo) {
-                        showConnPad = true;
-                    }
-                    else {
-                        showConnPad = !showConnPad;
-                    }
-                    topo = false;
-                    if (!showConnPad)
-                    {
-                        werase(connPad);
-                        prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
-                        drawMain();
-                    }
-                    break;
-                // w: Increase frame-rate of curses display
-                case 'w':
-                    if (updateRate > 100)
-                    {
-                        updateRate -= 100;
-                    }
-                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
-                    refresh();
-                    break;
-                // s: Decrease frame-rate of curses display
-                case 's':
-                    updateRate += 100;
-                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
-                    refresh();
-                    break;
-                // c: Display IP configuration menu
-                case 'c':
-                    drawCfg(1);
-                    break;
-                // h: Display help menu
-                case 'h':
-                    drawHelp();
-                    break;
-                case 'x':
-                    erase();
-                    endwin();
-                    return 0;
-                    break;
-                case KEY_UP:
-                    if (padSelection == 0)
-                    {
-                        meshScroll++;
-                    }
-                    else if (padSelection == 1)
-                    {
-                        connScroll++;
-                    }
-                    break;
-                case KEY_DOWN:
-                    if (padSelection == 0)
-                    {
-                        meshScroll--;
-                    }
-                    else if (padSelection == 1)
-                    {
-                        connScroll--;
-                    }
-                    break;
-                case KEY_RIGHT:
-                    padSelection++;
-                    padSelection = std::min(padSelection, 1);
-                    break; //right
-                case KEY_LEFT:
-                    padSelection--;
-                    padSelection = std::max(padSelection, 0);
-                    break; //left
-                case 'Q':
-                    erase();
-                    endwin();
-                    return 0;
-                    break;
-                    meshScroll = std::max(meshScroll, 0);
-                    connScroll = std::max(connScroll, 0);
-                    meshInfoTimer = 0;
-                case 't':
-                    topo = true;
-                    showConnPad = true;
-                    break;
-            }
+        // Handles keyboard inputs etc.
+        if(!handleKeyPad()){
+            return 0;
         }
 
         //This section checks for failures detected by RF24 & RF24Network as well as
@@ -356,16 +259,17 @@ int main()
                     myFile << ++failCounter << "\n";
                 }
                 myFile.close();
-                mesh.begin(75);
+                mesh.begin();
                 delay(1000);
+                clear();
+                drawMain();
+                meshInfoTimer -= 1000;
                 radio.failureDetected = 0;
             }
         }
 
     } //while 1
 
-    //delwin(meshPad);
-    //delwin(connPad);
     erase();
     endwin();
     return 0;
@@ -774,3 +678,106 @@ void drawConnPad()
 }
 
 /******************************************************************/
+
+        /** Handle keyboard input **/
+        /*******************************/
+bool handleKeyPad(){
+
+        int myChar = getch();
+
+        if (myChar > -1)
+        {
+            //cout << myChar << endl;
+            switch (myChar)
+            {
+                // a: En/Disable display of active connections
+                case 'a':
+                    if (topo) {
+                        showConnPad = true;
+                    }
+                    else {
+                        showConnPad = !showConnPad;
+                    }
+                    topo = false;
+                    if (!showConnPad)
+                    {
+                        werase(connPad);
+                        prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
+                        drawMain();
+                    }
+                    break;
+                // w: Increase frame-rate of curses display
+                case 'w':
+                    if (updateRate > 100)
+                    {
+                        updateRate -= 100;
+                    }
+                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
+                    refresh();
+                    break;
+                // s: Decrease frame-rate of curses display
+                case 's':
+                    updateRate += 100;
+                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
+                    refresh();
+                    break;
+                // c: Display IP configuration menu
+                case 'c':
+                    drawCfg(1);
+                    break;
+                // h: Display help menu
+                case 'h':
+                    drawHelp();
+                    break;
+                case 'x':
+                    erase();
+                    endwin();
+                    return 0;
+                    break;
+                case KEY_UP:
+                    if (padSelection == 0)
+                    {
+                        meshScroll++;
+                    }
+                    else if (padSelection == 1)
+                    {
+                        connScroll++;
+                    }
+                    break;
+                case KEY_DOWN:
+                    if (padSelection == 0)
+                    {
+                        meshScroll--;
+                    }
+                    else if (padSelection == 1)
+                    {
+                        connScroll--;
+                    }
+                    break;
+                case KEY_RIGHT:
+                    padSelection++;
+                    padSelection = std::min(padSelection, 1);
+                    break; //right
+                case KEY_LEFT:
+                    padSelection--;
+                    padSelection = std::max(padSelection, 0);
+                    break; //left
+                case 'Q':
+                    erase();
+                    endwin();
+                    return 0;
+                    break;
+                    meshScroll = std::max(meshScroll, 0);
+                    connScroll = std::max(connScroll, 0);
+                    meshInfoTimer = 0;
+                case 't':
+                    topo = true;
+                    showConnPad = !showConnPad;
+                    clear();
+                    drawMain();
+                    meshInfoTimer -= 1000;
+                    break;
+            }
+        }
+        return 1;
+}

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -153,6 +153,7 @@ int main()
     /***********************LOOP***************************************/
     bool ok = true;
     uint32_t failCounter = 0;
+    uint32_t failTimer = 0;
 
     while (1)
     {
@@ -215,7 +216,7 @@ int main()
          * The gateway handles all IP traffic (marked as EXTERNAL_DATA_TYPE) and passes it to the associated network interface
          * RF24Network user payloads are loaded into the user cache
          */
-        gw.poll(2);
+        gw.poll(1);
 
         /** Mesh address/id printout **/
         /*******************************/
@@ -343,19 +344,22 @@ int main()
         //checking for deviations from the default configuration (1MBPS data rate)
         //The mesh is restarted on failure and failure count logged to failLog.txt
         //This makes the radios hot-swappable, disconnect & reconnect as desired, it should come up automatically
-        if (radio.failureDetected > 0 || radio.getDataRate() != RF24_1MBPS)
-        {
-
-            std::ofstream myFile;
-            myFile.open("failLog.txt");
-            if (myFile.is_open())
+        if (millis() - failTimer > 1000) {
+            failTimer = millis();
+            if (radio.failureDetected > 0 || radio.getDataRate() != RF24_1MBPS)
             {
-                myFile << ++failCounter << "\n";
+
+                std::ofstream myFile;
+                myFile.open("failLog.txt");
+                if (myFile.is_open())
+                {
+                    myFile << ++failCounter << "\n";
+                }
+                myFile.close();
+                mesh.begin(75);
+                delay(1000);
+                radio.failureDetected = 0;
             }
-            myFile.close();
-            mesh.begin();
-            delay(1000);
-            radio.failureDetected = 0;
         }
 
     } //while 1

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -766,9 +766,6 @@ bool handleKeyPad()
                 endwin();
                 return 0;
                 break;
-                meshScroll = std::max(meshScroll, 0);
-                connScroll = std::max(connScroll, 0);
-                meshInfoTimer = 0;
             case 't':
                 topo = true;
                 showConnPad = !showConnPad;

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -146,7 +146,7 @@ int main()
     //gw.setIP(ip,subnet);
 
     drawMain();
-    if(!nodeID){
+    if (!nodeID) {
         showConnPad = true;
     }
     radio.maskIRQ(1, 1, 0);
@@ -203,7 +203,6 @@ int main()
             RF24NetworkHeader hdr(header.from_node, 1);
             network.write(hdr, &myTime, sizeof(myTime));
         }
-  
 
         /**
          * The gateway handles all IP traffic (marked as EXTERNAL_DATA_TYPE) and passes it to the associated network interface
@@ -237,9 +236,8 @@ int main()
             }
         } //MeshInfo Timer
 
-
         // Handles keyboard inputs etc.
-        if(!handleKeyPad()){
+        if (!handleKeyPad()) {
             return 0;
         }
 
@@ -679,105 +677,106 @@ void drawConnPad()
 
 /******************************************************************/
 
-        /** Handle keyboard input **/
-        /*******************************/
-bool handleKeyPad(){
+/** Handle keyboard input **/
+/*******************************/
+bool handleKeyPad()
+{
 
-        int myChar = getch();
+    int myChar = getch();
 
-        if (myChar > -1)
+    if (myChar > -1)
+    {
+        //cout << myChar << endl;
+        switch (myChar)
         {
-            //cout << myChar << endl;
-            switch (myChar)
-            {
-                // a: En/Disable display of active connections
-                case 'a':
-                    if (topo) {
-                        showConnPad = true;
-                    }
-                    else {
-                        showConnPad = !showConnPad;
-                    }
-                    topo = false;
-                    if (!showConnPad)
-                    {
-                        werase(connPad);
-                        prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
-                        drawMain();
-                    }
-                    break;
-                // w: Increase frame-rate of curses display
-                case 'w':
-                    if (updateRate > 100)
-                    {
-                        updateRate -= 100;
-                    }
-                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
-                    refresh();
-                    break;
-                // s: Decrease frame-rate of curses display
-                case 's':
-                    updateRate += 100;
-                    mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
-                    refresh();
-                    break;
-                // c: Display IP configuration menu
-                case 'c':
-                    drawCfg(1);
-                    break;
-                // h: Display help menu
-                case 'h':
-                    drawHelp();
-                    break;
-                case 'x':
-                    erase();
-                    endwin();
-                    return 0;
-                    break;
-                case KEY_UP:
-                    if (padSelection == 0)
-                    {
-                        meshScroll++;
-                    }
-                    else if (padSelection == 1)
-                    {
-                        connScroll++;
-                    }
-                    break;
-                case KEY_DOWN:
-                    if (padSelection == 0)
-                    {
-                        meshScroll--;
-                    }
-                    else if (padSelection == 1)
-                    {
-                        connScroll--;
-                    }
-                    break;
-                case KEY_RIGHT:
-                    padSelection++;
-                    padSelection = std::min(padSelection, 1);
-                    break; //right
-                case KEY_LEFT:
-                    padSelection--;
-                    padSelection = std::max(padSelection, 0);
-                    break; //left
-                case 'Q':
-                    erase();
-                    endwin();
-                    return 0;
-                    break;
-                    meshScroll = std::max(meshScroll, 0);
-                    connScroll = std::max(connScroll, 0);
-                    meshInfoTimer = 0;
-                case 't':
-                    topo = true;
+            // a: En/Disable display of active connections
+            case 'a':
+                if (topo) {
+                    showConnPad = true;
+                }
+                else {
                     showConnPad = !showConnPad;
-                    clear();
+                }
+                topo = false;
+                if (!showConnPad)
+                {
+                    werase(connPad);
+                    prefresh(connPad, 0, 0, 15, 1, maxX - 1, maxY - 2);
                     drawMain();
-                    meshInfoTimer -= 1000;
-                    break;
-            }
+                }
+                break;
+            // w: Increase frame-rate of curses display
+            case 'w':
+                if (updateRate > 100)
+                {
+                    updateRate -= 100;
+                }
+                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps", 1000.0 / updateRate);
+                refresh();
+                break;
+            // s: Decrease frame-rate of curses display
+            case 's':
+                updateRate += 100;
+                mvwprintw(win, 2, 27, "Refresh Rate: %.1f fps   \t", 1000.0 / updateRate);
+                refresh();
+                break;
+            // c: Display IP configuration menu
+            case 'c':
+                drawCfg(1);
+                break;
+            // h: Display help menu
+            case 'h':
+                drawHelp();
+                break;
+            case 'x':
+                erase();
+                endwin();
+                return 0;
+                break;
+            case KEY_UP:
+                if (padSelection == 0)
+                {
+                    meshScroll++;
+                }
+                else if (padSelection == 1)
+                {
+                    connScroll++;
+                }
+                break;
+            case KEY_DOWN:
+                if (padSelection == 0)
+                {
+                    meshScroll--;
+                }
+                else if (padSelection == 1)
+                {
+                    connScroll--;
+                }
+                break;
+            case KEY_RIGHT:
+                padSelection++;
+                padSelection = std::min(padSelection, 1);
+                break; //right
+            case KEY_LEFT:
+                padSelection--;
+                padSelection = std::max(padSelection, 0);
+                break; //left
+            case 'Q':
+                erase();
+                endwin();
+                return 0;
+                break;
+                meshScroll = std::max(meshScroll, 0);
+                connScroll = std::max(connScroll, 0);
+                meshInfoTimer = 0;
+            case 't':
+                topo = true;
+                showConnPad = !showConnPad;
+                clear();
+                drawMain();
+                meshInfoTimer -= 1000;
+                break;
         }
-        return 1;
+    }
+    return 1;
 }

--- a/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
+++ b/examples/ncursesInt/RF24Gateway_ncursesInt.cpp
@@ -232,7 +232,7 @@ int main()
             {
                 drawConnPad();
                 wscrl(connPad, connScroll);
-                prefresh(connPad, 0, 0, 18, 1, maxX - 1, maxY - 2);
+                prefresh(connPad, 0, 0, 17, 1, maxX - 1, maxY - 2);
             }
         } //MeshInfo Timer
 


### PR DESCRIPTION
- Change poll delay value to 1 in Interrupt examples - increases throughput at expense of CPU cycles
- Put failure detection on a timer
- An \n to ncurses example to fix display of corrupted packets

Still looking things over, may make further changes