### PR TITLE
Fixes for RF24Gateway

### DIFF
--- a/RF24Gateway.cpp
+++ b/RF24Gateway.cpp
@@ -396,7 +396,7 @@ void ESBGateway<mesh_t, network_t, radio_t>::handleRadioIn()
 
         msgStruct msg;
 
-        if (f.message_size > 0) {
+        if (f.message_size > 0 && f.message_size <= MAX_PAYLOAD_SIZE) {
             memcpy(&msg.message, &f.message_buffer, f.message_size);
             msg.size = f.message_size;
 
@@ -494,6 +494,11 @@ void ESBGateway<mesh_t, network_t, radio_t>::handleRadioOut()
 
         std::uint8_t* tmp = msgTx->message;
 
+        if (msgTx->size < 6) {
+            txQueue.pop();
+            return;
+        }
+
         if (!config_TUN) { // TAP can use RF24Mesh for address assignment, but will still use ARP for address resolution
 
             uint32_t RF24_STR = 0x34324652; // Identifies the mac as an RF24 mac
@@ -550,6 +555,11 @@ void ESBGateway<mesh_t, network_t, radio_t>::handleRadioOut()
             }
         }
         else { // TUN always needs to use RF24Mesh for address assignment AND resolution
+
+            if (msgTx->size < 20) {
+                txQueue.pop();
+                continue;
+            }
 
             uint8_t lastOctet = tmp[19];
             int16_t meshAddr;
@@ -758,6 +768,9 @@ void ESBGateway<mesh_t, network_t, radio_t>::sendUDP(uint8_t nodeID, RF24Network
 
     uint8_t buffer[MAX_PAYLOAD_SIZE + 11];
 
+    if (frame.message_size > MAX_PAYLOAD_SIZE) {
+        return;
+    }
     memcpy(&buffer[0], &nodeID, 1);
     memcpy(&buffer[1], &frame.header, 8);
     memcpy(&buffer[9], &frame.message_size, 2);

--- a/RF24Gateway.cpp
+++ b/RF24Gateway.cpp
@@ -494,9 +494,10 @@ void ESBGateway<mesh_t, network_t, radio_t>::handleRadioOut()
 
         std::uint8_t* tmp = msgTx->message;
 
+        // Ensure that at the length of the payload includes at least the MAC address
         if (msgTx->size < 6) {
             txQueue.pop();
-            return;
+            continue;
         }
 
         if (!config_TUN) { // TAP can use RF24Mesh for address assignment, but will still use ARP for address resolution
@@ -556,6 +557,7 @@ void ESBGateway<mesh_t, network_t, radio_t>::handleRadioOut()
         }
         else { // TUN always needs to use RF24Mesh for address assignment AND resolution
 
+            // Ensure that at least the 20-byte TCP/IP header is available
             if (msgTx->size < 20) {
                 txQueue.pop();
                 continue;


### PR DESCRIPTION
Fixes for RF24Gatway w/help from AI:

1. Potential stack/heap overflow from unchecked RF24 frame size

    File: /tmp/workspace/nRF24/RF24Gateway/RF24Gateway.cpp
    Function: ESBGateway::handleRadioIn
    Location: line 400 (memcpy(&msg.message, &f.message_buffer, f.message_size);)
    Why dangerous: msg.message is fixed-size (MAX_PAYLOAD_SIZE in header), but f.message_size is not bounded before copy.
    Risk: If f.message_size > MAX_PAYLOAD_SIZE, this overflows msg.message. Potentially exploitable if attacker can inject malformed/corrupted radio frames.

2. Unchecked payload length when packing UDP buffer

    File: /tmp/workspace/nRF24/RF24Gateway/RF24Gateway.cpp
    Function: ESBGateway::sendUDP
    Location: lines 759–766 (uint8_t buffer[MAX_PAYLOAD_SIZE + 11]; ... memcpy(... frame.message_size);)
    Why dangerous: Copies frame.message_size bytes into fixed stack buffer without validating frame.message_size <= MAX_PAYLOAD_SIZE.
    Risk: Stack overflow if oversized frame reaches this function. Could be exploitable depending on call path/input control.

3. Out-of-bounds reads during packet parsing (short packet not checked)

    File: /tmp/workspace/nRF24/RF24Gateway/RF24Gateway.cpp
    Function: ESBGateway::handleRadioOut
    Location: lines 508–509, 554, 561 (tmp+4, tmp[19], tmp[16])
    Why dangerous: Code reads specific offsets from msgTx->message before verifying minimum packet length.
    Risk: OOB read/crash with truncated packets from TUN/TAP input. Mostly robustness/DoS, but parser bugs are security-relevant.

